### PR TITLE
fix(ui): use netWorthChart field instead of shadowing local variable

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/PortfolioView.java
@@ -88,9 +88,7 @@ public class PortfolioView extends VBox implements Page, Observer {
   }
 
   private AreaChart<Number, Number> createNetWorthChart(PortfolioData portfolio) {
-    AreaChartView netWorthChart = new AreaChartView("Week", "Net Worth");
     netWorthChart.display("Net Worth Chart", portfolio.netWorthHistory());
-    netWorthChart.appendPoint(1, BigDecimal.TEN);
     netWorthChart.getChart().setLegendVisible(false);
     return netWorthChart.getChart();
 
@@ -161,9 +159,6 @@ public class PortfolioView extends VBox implements Page, Observer {
     });
     return col;
   }
-
-  // private TableColumn<ShareData, Void> createActionColumn() {
-  // }
 
   private BigDecimal calculateGain(ShareData shareData) {
     return shareData.currentShareValue()


### PR DESCRIPTION
createNetWorthChart() created a new local AreaChartView that shadowed the field. The local instance was added to the scene graph, while refresh() updated the unused field, so the chart never reflected portfolio changes.

Use the field directly and remove leftover debug appendPoint call