### PR TITLE
Feat/money format utility

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/shared/MoneyFormat.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/shared/MoneyFormat.java
@@ -1,0 +1,81 @@
+package edu.ntnu.idatt2003.gruppe50.shared;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Utility class for formatting monetary and percentage values.
+ *
+ * <p>The class formats {@link BigDecimal} values with two decimal places using
+ * {@link RoundingMode#HALF_UP}. Positive signed values are prefixed with a plus
+ * sign, while negative values keep their minus sign.</p>
+ */
+public final class MoneyFormat {
+
+  /**
+   * Formats a value with two decimal places.
+   *
+   * <p>If the given value is {@code null}, an empty string is returned.</p>
+   *
+   * @param value the value to format
+   * @return the formatted value with two decimal places, or an empty string if the value is {@code null}
+   */
+  public static String format(BigDecimal value) {
+    if (value == null) {
+      return "";
+    }
+    return value.setScale(2, RoundingMode.HALF_UP).toPlainString();
+  }
+
+  /**
+   * Formats a value with two decimal places and a sign prefix.
+   *
+   * <p>Positive values and zero are prefixed with {@code +}. Negative values keep
+   * their {@code -} sign from the formatted number. If the given value is
+   * {@code null}, an empty string is returned.</p>
+   *
+   * @param value the value to format
+   * @return the formatted signed value, or an empty string if the value is {@code null}
+   */
+  public static String formatSigned(BigDecimal value) {
+    if (value == null) {
+      return "";
+    }
+    BigDecimal scaled = value.setScale(2, RoundingMode.HALF_UP);
+    return (scaled.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "") + scaled.toPlainString();
+  }
+
+  /**
+   * Formats a value as a currency amount in Norwegian kroner.
+   *
+   * <p>The returned value includes a sign prefix and the {@code kr} suffix.
+   * If the given value is {@code null}, the result will be {@code " kr"}.If the given value is
+   * {@code null}, an empty string is returned.</p>
+   *
+   * @param value the currency value to format
+   * @return the formatted currency value
+   */
+  public static String formatCurrency(BigDecimal value) {
+    if (value == null) {
+      return "";
+    }
+    return formatSigned(value) + " kr";
+  }
+
+  /**
+   * Formats a value as a percentage.
+   *
+   * <p>The returned value includes a sign prefix and the {@code %} suffix.
+   * If the given value is {@code null}, the result will be {@code "%"}.If the given value is
+   * {@code null}, an empty string is returned.</p>
+   *
+   * @param value the percentage value to format
+   * @return the formatted percentage value
+   */
+  public static String formatPercent(BigDecimal value) {
+    if (value == null) {
+      return "";
+    }
+    return formatSigned(value) + "%";
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/shared/MoneyFormat.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/shared/MoneyFormat.java
@@ -41,21 +41,46 @@ public final class MoneyFormat {
     if (value == null) {
       return "";
     }
+
     BigDecimal scaled = value.setScale(2, RoundingMode.HALF_UP);
-    return (scaled.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "") + scaled.toPlainString();
+
+    if (scaled.compareTo(BigDecimal.ZERO) > 0) {
+      return "+" + scaled.toPlainString();
+    }
+
+    return scaled.toPlainString();
   }
 
   /**
    * Formats a value as a currency amount in Norwegian kroner.
    *
-   * <p>The returned value includes a sign prefix and the {@code kr} suffix.
-   * If the given value is {@code null}, the result will be {@code " kr"}.If the given value is
-   * {@code null}, an empty string is returned.</p>
+   * <p>The returned value does not include a sign prefix.</p>
+   *
+   * <p>If the given value is {@code null}, an empty string is returned.</p>
    *
    * @param value the currency value to format
-   * @return the formatted currency value
+   * @return the formatted currency value, or an empty string if the value is {@code null}
    */
+
   public static String formatCurrency(BigDecimal value) {
+    if (value == null) {
+      return "";
+    }
+    return format(value) + " kr";
+  }
+
+  /**
+   * Formats a value as a signed currency amount in Norwegian kroner.
+   *
+   * <p>Positive values and zero are prefixed with {@code +}. Negative values keep
+   * their minus sign.</p>
+   *
+   * <p>If the given value is {@code null}, an empty string is returned.</p>
+   *
+   * @param value the currency value to format
+   * @return the formatted signed currency value, or an empty string if the value is {@code null}
+   */
+  public static String formatSignedCurrency(BigDecimal value) {
     if (value == null) {
       return "";
     }
@@ -63,19 +88,21 @@ public final class MoneyFormat {
   }
 
   /**
-   * Formats a value as a percentage.
+   * Formats a value as a signed percentage.
    *
-   * <p>The returned value includes a sign prefix and the {@code %} suffix.
-   * If the given value is {@code null}, the result will be {@code "%"}.If the given value is
-   * {@code null}, an empty string is returned.</p>
+   * <p>Positive values and zero are prefixed with {@code +}. Negative values keep
+   * their minus sign.</p>
+   *
+   * <p>If the given value is {@code null}, an empty string is returned.</p>
    *
    * @param value the percentage value to format
-   * @return the formatted percentage value
+   * @return the formatted signed percentage value, or an empty string if the value is {@code null}
    */
-  public static String formatPercent(BigDecimal value) {
+  public static String formatSignedPercent(BigDecimal value) {
     if (value == null) {
       return "";
     }
     return formatSigned(value) + "%";
   }
+
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/MarketView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/MarketView.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
 
 import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.shared.MoneyFormat;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.MarketController;
 import java.math.BigDecimal;
 import javafx.beans.property.SimpleObjectProperty;
@@ -139,8 +140,24 @@ public class MarketView implements Page {
     col.setCellValueFactory(data ->
         new SimpleObjectProperty<>(data.getValue().getSalesPrice())
     );
+    col.setCellFactory(c -> createMoneyCell());
     col.setMaxWidth(1f * Integer.MAX_VALUE * 20);
     return col;
+  }
+
+  private TableCell<Stock, BigDecimal> createMoneyCell() {
+    return new TableCell<>() {
+      @Override
+      protected void updateItem(BigDecimal value, boolean empty) {
+        super.updateItem(value, empty);
+
+        if (empty || value == null) {
+          setText(null);
+        } else {
+          setText(MoneyFormat.formatCurrency(value));
+        }
+      }
+    };
   }
 
   private TableColumn<Stock, BigDecimal> createChangeColumn() {
@@ -148,9 +165,26 @@ public class MarketView implements Page {
     col.setCellValueFactory(data ->
         new SimpleObjectProperty<>(data.getValue().getLatestPriceChange())
     );
-    col.setCellFactory(c -> createColoredCell());
+    col.setCellFactory(c -> createColoredCurrencyCell());
     col.setMaxWidth(1f * Integer.MAX_VALUE * 20);
     return col;
+  }
+
+  private TableCell<Stock, BigDecimal> createColoredCurrencyCell() {
+    return new TableCell<>() {
+      @Override
+      protected void updateItem(BigDecimal value, boolean empty) {
+        super.updateItem(value, empty);
+
+        if (empty || value == null) {
+          setText(null);
+          setStyle("");
+        } else {
+          setText(MoneyFormat.formatSignedCurrency(value));
+          setStyle(gainStyle(value));
+        }
+      }
+    };
   }
 
   private TableColumn<Stock, BigDecimal> createPercentChangeColumn() {
@@ -158,37 +192,34 @@ public class MarketView implements Page {
     col.setCellValueFactory(data ->
         new SimpleObjectProperty<>(data.getValue().getLatestPriceChangePercent())
     );
-    col.setCellFactory(c -> createColoredCell());
+    col.setCellFactory(c -> createColoredPercentCell());
     col.setMaxWidth(1f * Integer.MAX_VALUE * 20);
     return col;
   }
 
-  /**
-   * Creates a table cell that displays a {@link BigDecimal} value with
-   * color coding based on its sign. Positive values are green,
-   * negative values are red, and zero is white.
-   *
-   * @return a configured {@link TableCell}
-   */
-  private TableCell<Stock, BigDecimal> createColoredCell() {
+  private TableCell<Stock, BigDecimal> createColoredPercentCell() {
     return new TableCell<>() {
       @Override
       protected void updateItem(BigDecimal value, boolean empty) {
         super.updateItem(value, empty);
+
         if (empty || value == null) {
           setText(null);
           setStyle("");
         } else {
-          setText(value.toString());
-          if (value.compareTo(BigDecimal.ZERO) > 0) {
-            setStyle("-fx-text-fill: #4CAF50;");
-          } else if (value.compareTo(BigDecimal.ZERO) < 0) {
-            setStyle("-fx-text-fill: #EF5350;");
-          } else {
-            setStyle("-fx-text-fill: #E0E0E0;");
-          }
+          setText(MoneyFormat.formatSignedPercent(value));
+          setStyle(gainStyle(value));
         }
       }
     };
+  }
+
+  private String gainStyle(BigDecimal value) {
+    if (value.compareTo(BigDecimal.ZERO) > 0) {
+      return "-fx-text-fill: #4CAF50;";
+    } else if (value.compareTo(BigDecimal.ZERO) < 0) {
+      return "-fx-text-fill: #EF5350;";
+    }
+    return "-fx-text-fill: #E0E0E0;";
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/PortfolioView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/PortfolioView.java
@@ -1,6 +1,6 @@
 package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
 
-
+import edu.ntnu.idatt2003.gruppe50.shared.MoneyFormat;
 import edu.ntnu.idatt2003.gruppe50.shared.observer.Observer;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.GameController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.PortfolioQueryController;
@@ -36,7 +36,6 @@ public class PortfolioView extends VBox implements Page, Observer {
   public PortfolioView(PortfolioQueryController queryController, GameController gameController) {
     this.queryController = queryController;
 
-    // Lag komponenter
     Label title = new Label("Portfolio");
     Label holdingsTitle = new Label("My holdings");
 
@@ -101,9 +100,9 @@ public class PortfolioView extends VBox implements Page, Observer {
     table.getColumns().addAll(
         createColumn("Symbol",         ShareData::symbol),
         createColumn("Company",        ShareData::stock),
-        createColumn("Quantity",       s -> s.quantity().toString()),
-        createColumn("Purchase price", s -> s.purchasePrice().toString()),
-        createColumn("Current value",  s -> s.currentShareValue().toString()),
+        createColumn("Quantity",       s -> MoneyFormat.format(s.quantity())),
+        createColumn("Purchase price", s -> MoneyFormat.formatCurrency(s.purchasePrice())),
+        createColumn("Current value",  s -> MoneyFormat.formatCurrency(s.currentShareValue())),
         createGainColumn(),
         createPercentColumn()
     );
@@ -132,7 +131,7 @@ public class PortfolioView extends VBox implements Page, Observer {
           setText(null);
           setStyle("");
         } else {
-          setText((value.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "") + value + " kr");
+          setText(MoneyFormat.formatSignedCurrency(value));
           setStyle(gainStyle(value));
         }
       }
@@ -152,7 +151,7 @@ public class PortfolioView extends VBox implements Page, Observer {
           setText(null);
           setStyle("");
         } else {
-          setText((value.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "") + value + "%");
+          setText(MoneyFormat.formatSignedPercent(value));
           setStyle(gainStyle(value));
         }
       }
@@ -174,9 +173,12 @@ public class PortfolioView extends VBox implements Page, Observer {
   }
 
   private String gainStyle(BigDecimal value) {
-    return value.compareTo(BigDecimal.ZERO) >= 0
-        ? "-fx-text-fill: #4CAF50;"
-        : "-fx-text-fill: #E24B4A;";
+    if (value.compareTo(BigDecimal.ZERO) > 0) {
+      return "-fx-text-fill: #4CAF50;";
+    } else if (value.compareTo(BigDecimal.ZERO) < 0) {
+      return "-fx-text-fill: #E24B4A;";
+    }
+    return "-fx-text-fill: #E0E0E0;";
   }
 
   @Override
@@ -186,12 +188,10 @@ public class PortfolioView extends VBox implements Page, Observer {
 
   private void refresh() {
     PortfolioData p = queryController.getPortfolio();
-    netWorthLabel.setText(p.netWorth().toString());
-    portfolioValueLabel.setText(p.portfolioValue().toString());
-    playerCashLabel.setText(p.cash().toString());
+    netWorthLabel.setText(MoneyFormat.formatCurrency(p.netWorth()));
+    portfolioValueLabel.setText(MoneyFormat.formatCurrency(p.portfolioValue()));
+    playerCashLabel.setText(MoneyFormat.formatCurrency(p.cash()));
     table.getItems().setAll(p.shares());
     netWorthChart.display("Net Worth", p.netWorthHistory());
   }
-
-
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/TransactionsView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/TransactionsView.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
 
 import edu.ntnu.idatt2003.gruppe50.application.query.TransactionType;
+import edu.ntnu.idatt2003.gruppe50.shared.MoneyFormat;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.TransactionQueryController;
 import edu.ntnu.idatt2003.gruppe50.ui.model.TransactionData;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.factory.ColumnDefinition;
@@ -55,9 +56,15 @@ public class TransactionsView extends BorderPane implements Page {
         new ColumnDefinition<>("Company", t -> new ReadOnlyStringWrapper(t.share().stock())),
         new ColumnDefinition<>("Type", t -> new ReadOnlyStringWrapper(t.type().name())),
         new ColumnDefinition<>("Week", t -> new ReadOnlyObjectWrapper<>(t.week())),
-        new ColumnDefinition<>("Commission", t -> new ReadOnlyStringWrapper(t.commissionFee().toString())),
-        new ColumnDefinition<>("Tax", t -> new ReadOnlyStringWrapper(t.taxFee().toString())),
-        new ColumnDefinition<>("Total", t -> new ReadOnlyStringWrapper(t.total().toString()))
+        new ColumnDefinition<>("Commission", t ->
+            new ReadOnlyStringWrapper(MoneyFormat.formatCurrency(t.commissionFee()))
+        ),
+        new ColumnDefinition<>("Tax", t ->
+            new ReadOnlyStringWrapper(MoneyFormat.formatCurrency(t.taxFee()))
+        ),
+        new ColumnDefinition<>("Total", t ->
+            new ReadOnlyStringWrapper(MoneyFormat.formatCurrency(t.total()))
+        )
     ));
     transactionTable.setPlaceholder(new Label("No transactions yet."));
     return transactionTable;


### PR DESCRIPTION
## Summary

This PR centralizes money and percentage formatting by introducing and using `MoneyFormat` across the UI.

## Changes

- Added reusable formatting methods in `MoneyFormat`
  - regular number formatting
  - signed number formatting
  - currency formatting
  - signed currency formatting
  - percent formatting
  - signed percent formatting
- Updated `MarketView` to use `MoneyFormat` for:
  - stock prices
  - price changes in kr
  - percentage changes
- Updated `PortfolioView` to use `MoneyFormat` for:
  - net worth
  - portfolio value
  - cash balance
  - purchase price
  - current value
  - gain/loss
  - percentage change
- Updated `TransactionsView` to use `MoneyFormat` for:
  - commission fee
  - tax fee
  - total transaction amount
- Kept visual styling, such as gain/loss colors, inside the view layer.

## Why

This makes formatting more consistent across the application and avoids duplicated formatting logic in different views. It also keeps `MoneyFormat` focused on text formatting, while the views remain responsible for visual styling.