### PR TITLE
fix: use log-normal distribution for stock price updates

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
@@ -172,8 +172,7 @@ public class Exchange extends Observable {
     this.week++;
 
     stockMap.replaceAll((_, stock) -> {
-      double change = -0.2 + random.nextDouble() * 0.4;
-      BigDecimal multiplier = BigDecimal.valueOf(1 + change);
+      BigDecimal multiplier = BigDecimal.valueOf(Math.exp((random.nextDouble() - 0.5) * 0.4));
 
       BigDecimal newPrice = stock.getSalesPrice().multiply(multiplier);
       stock.addNewSalesPrice(newPrice);


### PR DESCRIPTION
Previous implementation used uniform random percentage change which caused prices to drift downward over time due to asymmetry of multiplicative up/down moves (e.g. +20% then -20% = -4% net).

Replaced with geometric Brownian motion model using Math.exp() on a uniform log-change, ensuring symmetric expected value over time.