### PR TITLE
feat: add advanced order types and pending orders page

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/App.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/App.java
@@ -4,8 +4,11 @@ import edu.ntnu.idatt2003.gruppe50.application.GameSessionNotFoundException;
 import edu.ntnu.idatt2003.gruppe50.application.command.AdvanceWeekUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.LoadGameSessionUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceBuyLimitOrderUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceSellLimitOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.StartGameSessionUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.query.GetPendingOrdersUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPortfolioUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetTransactionsUseCase;
 import edu.ntnu.idatt2003.gruppe50.domain.game.GameSession;
@@ -17,6 +20,7 @@ import edu.ntnu.idatt2003.gruppe50.infrastructure.CSVFileHandler;
 import edu.ntnu.idatt2003.gruppe50.infrastructure.repository.InMemoryGameSessionRepository;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.GameController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.NewGameController;
+import edu.ntnu.idatt2003.gruppe50.ui.controller.OrdersController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.PortfolioQueryController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.TransactionQueryController;
 import edu.ntnu.idatt2003.gruppe50.ui.view.pages.GameViewCoordinator;
@@ -42,6 +46,10 @@ public class App extends Application {
   private final AdvanceWeekUseCase advanceWeek = new AdvanceWeekUseCase(sessions);
   private final GetPortfolioUseCase getPortfolio = new GetPortfolioUseCase(sessions);
   private final GetTransactionsUseCase getTransactions = new GetTransactionsUseCase(sessions);
+  private final PlaceBuyLimitOrderUseCase buyLimitOrder = new PlaceBuyLimitOrderUseCase(sessions);
+  private final PlaceSellLimitOrderUseCase sellLimitOrder = new PlaceSellLimitOrderUseCase(sessions);
+  private final GetPendingOrdersUseCase getPendingOrders = new GetPendingOrdersUseCase(sessions);
+
   private Stage stage;
 
   static void main(String[] args) {
@@ -83,6 +91,8 @@ public class App extends Application {
         new PortfolioQueryController(gameId, getPortfolio, session.getExchange());
     TransactionQueryController transactionQueryController =
         new TransactionQueryController(gameId, getTransactions, session.getExchange());
+    OrdersController ordersController =
+        new OrdersController(gameId, getPendingOrders);
     GameViewCoordinator gameViewCoordinator = new GameViewCoordinator(
         gameController,
         portfolioQueryController,
@@ -92,7 +102,10 @@ public class App extends Application {
         gameId,
         session.getExchange(),
         session.getPlayer(),
-        getPortfolio
+        getPortfolio,
+        buyLimitOrder,
+        sellLimitOrder,
+        ordersController
     );
 
 

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/App.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/App.java
@@ -6,6 +6,7 @@ import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.LoadGameSessionUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.PlaceBuyLimitOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.PlaceSellLimitOrderUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceStopLossOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.StartGameSessionUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPendingOrdersUseCase;
@@ -49,6 +50,7 @@ public class App extends Application {
   private final PlaceBuyLimitOrderUseCase buyLimitOrder = new PlaceBuyLimitOrderUseCase(sessions);
   private final PlaceSellLimitOrderUseCase sellLimitOrder = new PlaceSellLimitOrderUseCase(sessions);
   private final GetPendingOrdersUseCase getPendingOrders = new GetPendingOrdersUseCase(sessions);
+  private final PlaceStopLossOrderUseCase stopLossOrder = new PlaceStopLossOrderUseCase(sessions);
 
   private Stage stage;
 
@@ -105,6 +107,7 @@ public class App extends Application {
         getPortfolio,
         buyLimitOrder,
         sellLimitOrder,
+        stopLossOrder,
         ordersController
     );
 

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/PlaceBuyLimitOrderUseCase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/PlaceBuyLimitOrderUseCase.java
@@ -1,0 +1,59 @@
+package edu.ntnu.idatt2003.gruppe50.application.command;
+
+import edu.ntnu.idatt2003.gruppe50.application.GameSessionNotFoundException;
+import edu.ntnu.idatt2003.gruppe50.domain.game.GameSession;
+import edu.ntnu.idatt2003.gruppe50.domain.repository.GameSessionRepository;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/** Places a buy limit order inside a game session and saves the updated state. */
+public final class PlaceBuyLimitOrderUseCase {
+
+  private final GameSessionRepository repository;
+
+  /**
+   * Creates the use case with a game-session repository.
+   *
+   * @param repository repository used to load and save game sessions
+   */
+  public PlaceBuyLimitOrderUseCase(GameSessionRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Executes a buy limit order placement for an existing game session.
+   *
+   * @param request input with game id, symbol, quantity, target price and duration
+   * @throws GameSessionNotFoundException if the session does not exist
+   */
+  public void execute(Request request) {
+    GameSession session =
+        repository.findById(request.gameId()).orElseThrow(GameSessionNotFoundException::new);
+
+    session.placeBuyLimitOrder(
+        request.symbol(),
+        request.quantity(),
+        request.targetPrice(),
+        request.duration()
+    );
+
+    repository.save(session);
+  }
+
+  /**
+   * Input for placing a buy limit order in a session.
+   *
+   * @param gameId id of the game session
+   * @param symbol stock symbol to buy
+   * @param quantity quantity to buy
+   * @param targetPrice maximum price the player is willing to buy at
+   * @param duration number of weeks the order should stay active
+   */
+  public record Request(
+      UUID gameId,
+      String symbol,
+      BigDecimal quantity,
+      BigDecimal targetPrice,
+      int duration
+  ) {}
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/PlaceSellLimitOrderUseCase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/PlaceSellLimitOrderUseCase.java
@@ -1,0 +1,39 @@
+package edu.ntnu.idatt2003.gruppe50.application.command;
+
+import edu.ntnu.idatt2003.gruppe50.application.GameSessionNotFoundException;
+import edu.ntnu.idatt2003.gruppe50.domain.game.GameSession;
+import edu.ntnu.idatt2003.gruppe50.domain.repository.GameSessionRepository;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/** Places a sell limit order inside a game session and saves the updated state. */
+public final class PlaceSellLimitOrderUseCase {
+
+  private final GameSessionRepository repository;
+
+  public PlaceSellLimitOrderUseCase(GameSessionRepository repository) {
+    this.repository = repository;
+  }
+
+  public void execute(Request request) {
+    GameSession session =
+        repository.findById(request.gameId()).orElseThrow(GameSessionNotFoundException::new);
+
+    session.placeSellLimitOrder(
+        request.symbol(),
+        request.quantity(),
+        request.targetPrice(),
+        request.duration()
+    );
+
+    repository.save(session);
+  }
+
+  public record Request(
+      UUID gameId,
+      String symbol,
+      BigDecimal quantity,
+      BigDecimal targetPrice,
+      int duration
+  ) {}
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/PlaceStopLossOrderUseCase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/PlaceStopLossOrderUseCase.java
@@ -1,0 +1,39 @@
+package edu.ntnu.idatt2003.gruppe50.application.command;
+
+import edu.ntnu.idatt2003.gruppe50.application.GameSessionNotFoundException;
+import edu.ntnu.idatt2003.gruppe50.domain.game.GameSession;
+import edu.ntnu.idatt2003.gruppe50.domain.repository.GameSessionRepository;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/** Places a stop-loss order inside a game session and saves the updated state. */
+public final class PlaceStopLossOrderUseCase {
+
+  private final GameSessionRepository repository;
+
+  public PlaceStopLossOrderUseCase(GameSessionRepository repository) {
+    this.repository = repository;
+  }
+
+  public void execute(Request request) {
+    GameSession session =
+        repository.findById(request.gameId()).orElseThrow(GameSessionNotFoundException::new);
+
+    session.placeStopLossOrder(
+        request.symbol(),
+        request.quantity(),
+        request.targetPrice(),
+        request.duration()
+    );
+
+    repository.save(session);
+  }
+
+  public record Request(
+      UUID gameId,
+      String symbol,
+      BigDecimal quantity,
+      BigDecimal targetPrice,
+      int duration
+  ) {}
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/SellShareUseCase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/application/command/SellShareUseCase.java
@@ -3,6 +3,8 @@ package edu.ntnu.idatt2003.gruppe50.application.command;
 import edu.ntnu.idatt2003.gruppe50.application.GameSessionNotFoundException;
 import edu.ntnu.idatt2003.gruppe50.domain.game.GameSession;
 import edu.ntnu.idatt2003.gruppe50.domain.repository.GameSessionRepository;
+
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /** Sells an owned share inside a game session and saves updated state. */
@@ -29,7 +31,8 @@ public final class SellShareUseCase {
     GameSession session =
         repository.findById(request.gameId()).orElseThrow(GameSessionNotFoundException::new);
 
-    session.sell(request.shareId());
+    session.sell(request.symbol(), request.quantity());
+
     repository.save(session);
   }
 
@@ -39,5 +42,5 @@ public final class SellShareUseCase {
    * @param gameId id of the game session
    * @param shareId id of the owned share to sell
    */
-  public record Request(UUID gameId, UUID shareId) {}
+  public record Request(UUID gameId, String symbol, BigDecimal quantity) {}
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/application/query/GetPendingOrdersUseCase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/application/query/GetPendingOrdersUseCase.java
@@ -1,0 +1,22 @@
+package edu.ntnu.idatt2003.gruppe50.application.query;
+
+import edu.ntnu.idatt2003.gruppe50.application.GameSessionNotFoundException;
+import edu.ntnu.idatt2003.gruppe50.domain.repository.GameSessionRepository;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
+import java.util.List;
+import java.util.UUID;
+
+public final class GetPendingOrdersUseCase {
+
+  private final GameSessionRepository repository;
+
+  public GetPendingOrdersUseCase(GameSessionRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<LimitOrder> execute(UUID gameId) {
+    return repository.findById(gameId)
+        .orElseThrow(GameSessionNotFoundException::new)
+        .getPendingOrders();
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSession.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSession.java
@@ -1,7 +1,11 @@
 package edu.ntnu.idatt2003.gruppe50.domain.game;
 
 import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitBuyOrder;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitSellOrder;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -127,15 +131,73 @@ public final class GameSession {
     exchange.buy(symbol, quantity, player);
   }
 
+  public void placeBuyLimitOrder(
+      String symbol,
+      BigDecimal quantity,
+      BigDecimal targetPrice,
+      int duration
+  ) {
+    Validate.notBlank(symbol, "Symbol");
+    Validate.positive(quantity, "Quantity");
+    Validate.positive(targetPrice, "Target price");
+    Validate.positiveInt(duration, "Duration");
+
+    Stock stock = exchange.getStock(symbol);
+    int currentWeek = exchange.getWeek();
+    int expiryWeek = currentWeek + duration;
+
+    LimitBuyOrder order = new LimitBuyOrder(
+        stock,
+        player,
+        targetPrice,
+        quantity,
+        currentWeek,
+        expiryWeek
+    );
+
+    exchange.placeOrder(order);
+  }
+
   /**
    * Sells one owned share through the exchange for this session's player.
    *
    * @param shareId identifier of owned share to sell
    * @throws GameSessionFinishedException if the session is finished
    */
-  public void sell(UUID shareId) {
-    ensureActive();
-    exchange.sell(shareId, player);
+  public void sell(String symbol, BigDecimal quantity) {
+    Validate.notBlank(symbol, "Symbol");
+    Validate.positive(quantity, "Quantity");
+
+    Stock stock = exchange.getStock(symbol);
+
+    exchange.sellQuantity(stock, quantity, player);
+  }
+
+  public void placeSellLimitOrder(
+      String symbol,
+      BigDecimal quantity,
+      BigDecimal targetPrice,
+      int duration
+  ) {
+    Validate.notBlank(symbol, "Symbol");
+    Validate.positive(quantity, "Quantity");
+    Validate.positive(targetPrice, "Target price");
+    Validate.positiveInt(duration, "Duration");
+
+    Stock stock = exchange.getStock(symbol);
+    int currentWeek = exchange.getWeek();
+    int expiryWeek = currentWeek + duration;
+
+    LimitSellOrder order = new LimitSellOrder(
+        stock,
+        player,
+        targetPrice,
+        quantity,
+        currentWeek,
+        expiryWeek
+    );
+
+    exchange.placeOrder(order);
   }
 
   /**
@@ -218,5 +280,9 @@ public final class GameSession {
     if (state == GameSessionState.FINISHED) {
       throw new GameSessionFinishedException();
     }
+  }
+
+  public List<LimitOrder> getPendingOrders() {
+    return exchange.getPendingOrders();
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSession.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSession.java
@@ -166,6 +166,10 @@ public final class GameSession {
    * @throws GameSessionFinishedException if the session is finished
    */
   public void sell(String symbol, BigDecimal quantity) {
+    if (state == GameSessionState.FINISHED) {
+      throw new GameSessionFinishedException();
+    }
+
     Validate.notBlank(symbol, "Symbol");
     Validate.positive(quantity, "Quantity");
 

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSession.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSession.java
@@ -6,6 +6,7 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitBuyOrder;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitSellOrder;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.StopLossOrder;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -189,6 +190,33 @@ public final class GameSession {
     int expiryWeek = currentWeek + duration;
 
     LimitSellOrder order = new LimitSellOrder(
+        stock,
+        player,
+        targetPrice,
+        quantity,
+        currentWeek,
+        expiryWeek
+    );
+
+    exchange.placeOrder(order);
+  }
+
+  public void placeStopLossOrder(
+      String symbol,
+      BigDecimal quantity,
+      BigDecimal targetPrice,
+      int duration
+  ) {
+    Validate.notBlank(symbol, "Symbol");
+    Validate.positive(quantity, "Quantity");
+    Validate.positive(targetPrice, "Target price");
+    Validate.positiveInt(duration, "Duration");
+
+    Stock stock = exchange.getStock(symbol);
+    int currentWeek = exchange.getWeek();
+    int expiryWeek = currentWeek + duration;
+
+    StopLossOrder order = new StopLossOrder(
         stock,
         player,
         targetPrice,

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
@@ -357,6 +357,9 @@ public class Exchange extends Observable {
   public void placeOrder(LimitOrder order) {
     Validate.notNull(order, "Order");
     pendingOrders.add(order);
+
+    System.out.println("Pending orders: " + pendingOrders.size());
+
     notifyObservers();
   }
 

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
@@ -187,7 +187,7 @@ public class Exchange extends Observable {
    * @throws IllegalStateException if the player does not own enough shares of
    *     the given stock
    */
-  //LAG TEST
+  //LAG TESTER
   public List<Transaction> sellQuantity(Stock stock, BigDecimal quantity, Player player) {
     Validate.notNull(stock, "Stock");
     Validate.positive(quantity, "Quantity");
@@ -247,7 +247,9 @@ public class Exchange extends Observable {
   }
 
   /**
-   * Advances a week and randomizes stock prices.
+   * Advances a week and randomizes stock prices. Pending limit orders are
+   * checked: expired orders are removed, and orders whose trigger condition
+   * is met are executed.
    */
   public void advance() {
     this.week++;
@@ -259,7 +261,51 @@ public class Exchange extends Observable {
       stock.addNewSalesPrice(newPrice);
       return stock;
     });
+
+    processPendingOrders();
+
     notifyObservers();
+  }
+
+  /**
+   * Processes all pending limit orders for the current week.
+   *
+   * <p>For each order:
+   * <ul>
+   *   <li>If the order has expired, it is removed without execution.</li>
+   *   <li>If the order's trigger condition is met at the current price,
+   *       it is executed and removed. If execution fails (e.g. insufficient
+   *       funds or shares), the failure is logged and the order is removed.</li>
+   *   <li>Otherwise, the order remains pending.</li>
+   * </ul>
+   */
+  private void processPendingOrders() {
+    List<LimitOrder> toRemove = new ArrayList<>();
+
+    for (LimitOrder order : pendingOrders) {
+      if (order.isExpired(this.week)) {
+        // TODO: notify player that order expired
+        System.err.println("Order expired for " + order.getPlayer().getName()
+            + " on " + order.getStock().getSymbol());
+        toRemove.add(order);
+        continue;
+      }
+
+      BigDecimal currentPrice = order.getStock().getSalesPrice();
+      if (order.shouldTrigger(currentPrice)) {
+        try {
+          order.execute(this);
+        } catch (RuntimeException e) {
+          // TODO: notify player that order triggered but could not be executed
+          System.err.println("Order triggered but failed for "
+              + order.getPlayer().getName() + " on " + order.getStock().getSymbol()
+              + ": " + e.getMessage());
+        }
+        toRemove.add(order);
+      }
+    }
+
+    pendingOrders.removeAll(toRemove);
   }
 
   /**

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
@@ -4,10 +4,12 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.Transaction;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.TransactionFactory;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
 import edu.ntnu.idatt2003.gruppe50.shared.observer.Observable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +30,7 @@ public class Exchange extends Observable {
   private final Random random;
   private final TransactionFactory factory;
   private int week;
+  private final List<LimitOrder> pendingOrders = new ArrayList<>();
 
   /**
    * Creates a new {@code exchange} with a name and stocks represented by symbols.
@@ -134,7 +137,7 @@ public class Exchange extends Observable {
     Validate.notNull(player, "Player");
 
     Stock stock = getStock(symbol);
-    Share share = new Share(stock, quantity, stock.getSalesPrice());
+    Share share = new Share(stock, quantity, stock.getSalesPrice(), this.week);
 
     Transaction t = factory.createPurchase(share, this.week);
     t.commit(player);
@@ -219,4 +222,41 @@ public class Exchange extends Observable {
     return new ArrayList<>(stockMap.values());
   }
 
+  /**
+   * Places a pending limit order on the exchange. The order will be
+   * checked against the market price and executed when its trigger
+   * condition is met.
+   *
+   * @param order the order to place
+   * @throws IllegalArgumentException if {@code order} is null
+   */
+  public void placeOrder(LimitOrder order) {
+    Validate.notNull(order, "Order");
+    pendingOrders.add(order);
+    notifyObservers();
+  }
+
+  /**
+   * Cancels a pending limit order. If the order is not currently
+   * pending, this method has no effect.
+   *
+   * @param order the order to cancel
+   * @return true if the order was removed, false otherwise
+   */
+  public boolean cancelOrder(LimitOrder order) {
+    boolean removed = pendingOrders.remove(order);
+    if (removed) {
+      notifyObservers();
+    }
+    return removed;
+  }
+
+  /**
+   * Returns an unmodifiable view of all currently pending limit orders.
+   *
+   * @return the pending orders
+   */
+  public List<LimitOrder> getPendingOrders() {
+    return Collections.unmodifiableList(pendingOrders);
+  }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/Exchange.java
@@ -169,6 +169,84 @@ public class Exchange extends Observable {
   }
 
   /**
+   * Sells a given quantity of a stock from the player's portfolio using FIFO
+   * ordering (oldest shares first). If the requested quantity does not align
+   * exactly with the player's existing share lots, the final lot is split:
+   * the consumed portion is sold and the remainder is returned to the
+   * portfolio as a new share with the same purchase price and week.
+   *
+   * <p>All resulting sale transactions share the same {@code batchId} so that
+   * they can be presented as a single user action in the UI.
+   *
+   * @param stock the stock to sell
+   * @param quantity the total number of units to sell
+   * @param player the player selling
+   * @return the list of sale transactions created, in FIFO order
+   * @throws IllegalArgumentException if {@code stock} or {@code player} is null,
+   *     or {@code quantity} is not positive
+   * @throws IllegalStateException if the player does not own enough shares of
+   *     the given stock
+   */
+  //LAG TEST
+  public List<Transaction> sellQuantity(Stock stock, BigDecimal quantity, Player player) {
+    Validate.notNull(stock, "Stock");
+    Validate.positive(quantity, "Quantity");
+    Validate.notNull(player, "Player");
+
+    List<Share> lots = player.getPortfolio().getShares(stock.getSymbol()).stream()
+        .sorted(Comparator.comparingInt(Share::getPurchaseWeek))
+        .toList();
+
+    BigDecimal totalOwned = lots.stream()
+        .map(Share::getQuantity)
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    if (totalOwned.compareTo(quantity) < 0) {
+      throw new IllegalStateException(
+          "Player does not own enough shares of " + stock.getSymbol()
+              + " (owned: " + totalOwned + ", requested: " + quantity + ")");
+    }
+
+    UUID batchId = UUID.randomUUID();
+    List<Transaction> sales = new ArrayList<>();
+    BigDecimal remaining = quantity;
+
+    for (Share lot : lots) {
+      if (remaining.compareTo(BigDecimal.ZERO) <= 0) {
+        break;
+      }
+
+      BigDecimal lotQty = lot.getQuantity();
+
+      if (lotQty.compareTo(remaining) <= 0) {
+        // Sell the entire lot
+        Transaction sale = factory.createSale(lot, this.week, batchId);
+        sale.commit(player);
+        sales.add(sale);
+        remaining = remaining.subtract(lotQty);
+      } else {
+        // Split the lot: sell `remaining`, return (lotQty - remaining) to portfolio
+        player.getPortfolio().removeShare(lot.getShareId());
+
+        Share consumed = new Share(stock, remaining, lot.getPurchasePrice(), lot.getPurchaseWeek());
+        Share leftover = new Share(stock, lotQty.subtract(remaining),
+            lot.getPurchasePrice(), lot.getPurchaseWeek());
+
+        player.getPortfolio().addShare(consumed);
+        player.getPortfolio().addShare(leftover);
+
+        Transaction sale = factory.createSale(consumed, this.week, batchId);
+        sale.commit(player);
+        sales.add(sale);
+        remaining = BigDecimal.ZERO;
+      }
+    }
+
+    notifyObservers();
+    return sales;
+  }
+
+  /**
    * Advances a week and randomizes stock prices.
    */
   public void advance() {

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/Share.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/Share.java
@@ -16,6 +16,7 @@ public class Share {
   private final Stock stock;
   private final BigDecimal quantity;
   private final BigDecimal purchasePrice;
+  private final int purchaseWeek;
 
   /**
    * Creates a new {@code Share} with the given stock, quantity and purchase price.
@@ -25,17 +26,24 @@ public class Share {
    * @param purchasePrice the purchase price per unit
    * @throws IllegalArgumentException if any argument is null, zero or negative.
    */
-  public Share(Stock stock, BigDecimal quantity, BigDecimal purchasePrice) {
+  public Share(Stock stock, BigDecimal quantity, BigDecimal purchasePrice, int purchaseWeek) {
     shareId = UUID.randomUUID();
     Validate.notNull(stock, "Stock");
     Validate.positive(quantity, "Quantity");
     Validate.positive(purchasePrice, "Purchase price");
+    Validate.positiveInt(purchaseWeek, "Purchase week");
 
     this.stock = stock;
     this.quantity = quantity;
     this.purchasePrice = purchasePrice;
+    this.purchaseWeek = purchaseWeek;
   }
 
+  /**
+   * Returns the Share ID associated with this share
+   *
+   * @return the share ID
+   */
   public UUID getShareId() {
     return shareId;
   }
@@ -65,5 +73,14 @@ public class Share {
    */
   public BigDecimal getPurchasePrice() {
     return purchasePrice;
+  }
+
+  /**
+   * Returns the week this share was purchased.
+   *
+   * @return the purchase week
+   */
+  public int getPurchaseWeek() {
+    return purchaseWeek;
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Purchase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Purchase.java
@@ -5,6 +5,7 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.PurchaseCalculator;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
 import java.math.BigDecimal;
+import java.util.UUID;
 
 /**
  * Represents a transaction where a player buys shares.
@@ -14,10 +15,19 @@ import java.math.BigDecimal;
  */
 public class Purchase extends Transaction {
 
-  public Purchase(Share share, int week) {
-    super(share, week, new PurchaseCalculator(share));
+  /**
+   * Creates a new {@code Purchase} transaction.
+   *
+   * @param share the share being purchased
+   * @param week the week the purchase takes place
+   * @param batchId the id grouping this transaction with others
+   *     from the same user action
+   * @throws IllegalArgumentException if {@code share} or {@code batchId} is
+   *     {@code null}, or if {@code week} is not positive
+   */
+  public Purchase(Share share, int week, UUID batchId) {
+    super(share, week, new PurchaseCalculator(share), batchId);
   }
-
   /**
    * Commits this purchase transaction for the specified player.
    *

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Sale.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Sale.java
@@ -4,6 +4,7 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.SaleCalculator;
 import java.math.BigDecimal;
+import java.util.UUID;
 
 /**
  * Represents a transaction where a player sells shares.
@@ -13,8 +14,18 @@ import java.math.BigDecimal;
  */
 public class Sale extends Transaction {
 
-  public Sale(Share share, int week) {
-    super(share, week, new SaleCalculator(share));
+  /**
+   * Creates a new {@code Sale} transaction.
+   *
+   * @param share the share being sold
+   * @param week the week the sale takes place
+   * @param batchId the id grouping this transaction with others
+   *     from the same user action
+   * @throws IllegalArgumentException if {@code share} or {@code batchId} is
+   *     {@code null}, or if {@code week} is not positive
+   */
+  public Sale(Share share, int week, UUID batchId) {
+    super(share, week, new SaleCalculator(share), batchId);
   }
 
   /**

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Transaction.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Transaction.java
@@ -5,6 +5,8 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.TransactionCalculator;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
 
+import java.util.UUID;
+
 /**
  * Represents a financial transaction in the game.
  *
@@ -17,6 +19,7 @@ public abstract class Transaction {
   private final Share share;
   private final int week;
   private final TransactionCalculator calculator;
+  private final UUID batchId;
   private boolean committed;
 
   /**
@@ -28,13 +31,15 @@ public abstract class Transaction {
    * @throws IllegalArgumentException if {@code share} or {@code calculator} is
    *     {@code null}, or if {@code week} is not positive
    */
-  protected Transaction(Share share, int week, TransactionCalculator calculator) {
+  protected Transaction(Share share, int week, TransactionCalculator calculator, UUID batchId) {
     Validate.notNull(share, "Share");
     Validate.positiveInt(week, "Week");
     Validate.notNull(calculator, "Calculator");
+    Validate.notNull(batchId, "Batch id");
     this.share = share;
     this.week = week;
     this.calculator = calculator;
+    this.batchId = batchId;
   }
 
   /**
@@ -62,6 +67,16 @@ public abstract class Transaction {
    */
   public TransactionCalculator getCalculator() {
     return calculator;
+  }
+
+  /**
+   * Returns the batch id that groups this transaction with others from
+   * the same logical action.
+   *
+   * @return the batch id
+   */
+  public UUID getBatchId() {
+    return batchId;
   }
 
   /**

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Transaction.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/Transaction.java
@@ -19,9 +19,6 @@ public abstract class Transaction {
   private final TransactionCalculator calculator;
   private boolean committed;
 
-  // A good idea is that the transaction can be shown in the line chart,
-  // so that you can see when you bought and sold.
-
   /**
    * Creates a new {@code Transaction}.
    *

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionFactory.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionFactory.java
@@ -1,6 +1,7 @@
 package edu.ntnu.idatt2003.gruppe50.domain.trade;
 
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
+import java.util.UUID;
 
 /**
  * Factory class for creating financial transactions.
@@ -8,24 +9,38 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 public class TransactionFactory {
 
   /**
-   * Creates a new purchase transaction.
+   * Creates a new purchase transaction with a fresh batch id.
    *
    * @param share the share to be purchased
    * @param week the week the purchase takes place
    * @return a new {@link Transaction} representing the purchase
    */
   public Transaction createPurchase(Share share, int week) {
-    return new Purchase(share, week);
+    return new Purchase(share, week, UUID.randomUUID());
   }
 
   /**
-   * Creates a new sale transaction.
+   * Creates a new sale transaction with a fresh batch id.
    *
    * @param share the share to be sold
    * @param week the week the sale takes place
    * @return a new {@link Transaction} representing the sale
    */
   public Transaction createSale(Share share, int week) {
-    return new Sale(share, week);
+    return new Sale(share, week, UUID.randomUUID());
+  }
+
+  /**
+   * Creates a new sale transaction belonging to an existing batch.
+   * Used when a single user action results in multiple sale transactions
+   * (e.g. a sell crossing multiple FIFO lots).
+   *
+   * @param share the share to be sold
+   * @param week the week the sale takes place
+   * @param batchId the existing batch id to associate with this sale
+   * @return a new {@link Transaction} representing the sale
+   */
+  public Transaction createSale(Share share, int week, UUID batchId) {
+    return new Sale(share, week, batchId);
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitBuyOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitBuyOrder.java
@@ -1,0 +1,24 @@
+package edu.ntnu.idatt2003.gruppe50.domain.trade.order;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
+
+import java.math.BigDecimal;
+
+public class LimitBuyOrder extends LimitOrder{
+
+  public LimitBuyOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity) {
+    super(stock, player, targetPrice, quantity);
+  }
+
+  @Override
+  public boolean shouldTrigger(BigDecimal currentPrice) {
+    return getTargetPrice().compareTo(currentPrice) >= 0;
+  }
+
+  @Override
+  public void execute(Exchange exchange) {
+
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitBuyOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitBuyOrder.java
@@ -6,10 +6,24 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 
 import java.math.BigDecimal;
 
-public class LimitBuyOrder extends LimitOrder{
+public class LimitBuyOrder extends LimitOrder {
 
-  public LimitBuyOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity) {
-    super(stock, player, targetPrice, quantity);
+  /**
+   * Creates a new buy order with an explicit expiry week.
+   */
+  public LimitBuyOrder(Stock stock, Player player, BigDecimal targetPrice,
+                       BigDecimal quantity, int currentWeek, int expiryWeek) {
+    super(stock, player, targetPrice, quantity, currentWeek, expiryWeek);
+  }
+
+  /**
+   * Creates a new buy order with the default duration of
+   * {@link LimitOrder#DEFAULT_DURATION_WEEKS} weeks.
+   */
+  public LimitBuyOrder(Stock stock, Player player, BigDecimal targetPrice,
+                       BigDecimal quantity, int currentWeek) {
+    this(stock, player, targetPrice, quantity, currentWeek,
+        currentWeek + DEFAULT_DURATION_WEEKS);
   }
 
   @Override
@@ -19,6 +33,6 @@ public class LimitBuyOrder extends LimitOrder{
 
   @Override
   public void execute(Exchange exchange) {
-
+    exchange.buy(getStock().getSymbol(), getQuantity(), getPlayer());
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitOrder.java
@@ -19,6 +19,10 @@ public abstract class LimitOrder {
   private final Player player;
   private final BigDecimal targetPrice;
   private final BigDecimal quantity;
+  private final int expiryWeek;
+
+  public static final int DEFAULT_DURATION_WEEKS = 6;
+  public static final int MAX_DURATION_WEEKS = 12;
 
   /**
    * Creates a new limit order.
@@ -31,17 +35,31 @@ public abstract class LimitOrder {
    * @throws IllegalArgumentException if {@code targetPrice} or {@code quantity}
    *                                  is not positive
    */
-  protected LimitOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity) {
+  protected LimitOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity,int currentWeek, int expiryWeek) {
     Validate.notNull(stock, "stock");
     Validate.notNull(player, "player");
     Validate.notNull(targetPrice, "targetPrice");
     Validate.positive(targetPrice, "targetPrice");
     Validate.positive(quantity, "quantity");
+    Validate.positiveInt(currentWeek, "Current week");
+    Validate.positiveInt(expiryWeek, "Expiry week");
+    if (expiryWeek <= currentWeek) {
+      throw new IllegalArgumentException(
+          "Expiry week must be after current week (current: "
+              + currentWeek + ", expiry: " + expiryWeek + ")");
+    }
+    int duration = expiryWeek - currentWeek;
+    if (duration > MAX_DURATION_WEEKS) {
+      throw new IllegalArgumentException(
+          "Order duration cannot exceed " + MAX_DURATION_WEEKS
+              + " weeks (requested: " + duration + ")");
+    }
 
     this.stock = stock;
     this.player = player;
     this.targetPrice = targetPrice;
     this.quantity = quantity;
+    this.expiryWeek = expiryWeek;
   }
 
   public Stock getStock() {
@@ -58,6 +76,14 @@ public abstract class LimitOrder {
 
   public BigDecimal getQuantity() {
     return quantity;
+  }
+
+  public int getExpiryWeek() {
+    return expiryWeek;
+  }
+
+  public boolean isExpired(int currentWeek) {
+    return currentWeek > expiryWeek;
   }
 
   /**

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitOrder.java
@@ -20,6 +20,7 @@ public abstract class LimitOrder {
   private final BigDecimal targetPrice;
   private final BigDecimal quantity;
   private final int expiryWeek;
+  private final int currentWeek;
 
   public static final int DEFAULT_DURATION_WEEKS = 6;
   public static final int MAX_DURATION_WEEKS = 12;
@@ -60,6 +61,7 @@ public abstract class LimitOrder {
     this.targetPrice = targetPrice;
     this.quantity = quantity;
     this.expiryWeek = expiryWeek;
+    this.currentWeek = currentWeek;
   }
 
   public Stock getStock() {
@@ -76,6 +78,10 @@ public abstract class LimitOrder {
 
   public BigDecimal getQuantity() {
     return quantity;
+  }
+
+  public int getCreatedWeek() {
+    return currentWeek;
   }
 
   public int getExpiryWeek() {

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitOrder.java
@@ -1,0 +1,79 @@
+package edu.ntnu.idatt2003.gruppe50.domain.trade.order;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
+import edu.ntnu.idatt2003.gruppe50.shared.Validate;
+import java.math.BigDecimal;
+
+/**
+ * Represents a pending limit order placed by a player on the exchange.
+ * A limit order is executed automatically when the market price reaches
+ * the player's target price.
+ *
+ * <p>Subclasses define the trigger condition and execution logic
+ * for buy and sell orders respectively.</p>
+ */
+public abstract class LimitOrder {
+  private final Stock stock;
+  private final Player player;
+  private final BigDecimal targetPrice;
+  private final BigDecimal quantity;
+
+  /**
+   * Creates a new limit order.
+   *
+   * @param stock       the stock the order applies to
+   * @param player      the player placing the order
+   * @param targetPrice the price at which the order should trigger
+   * @param quantity    the number of shares
+   * @throws NullPointerException     if any reference argument is null
+   * @throws IllegalArgumentException if {@code targetPrice} or {@code quantity}
+   *                                  is not positive
+   */
+  protected LimitOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity) {
+    Validate.notNull(stock, "stock");
+    Validate.notNull(player, "player");
+    Validate.notNull(targetPrice, "targetPrice");
+    Validate.positive(targetPrice, "targetPrice");
+    Validate.positive(quantity, "quantity");
+
+    this.stock = stock;
+    this.player = player;
+    this.targetPrice = targetPrice;
+    this.quantity = quantity;
+  }
+
+  public Stock getStock() {
+    return stock;
+  }
+
+  public Player getPlayer() {
+    return player;
+  }
+
+  public BigDecimal getTargetPrice() {
+    return targetPrice;
+  }
+
+  public BigDecimal getQuantity() {
+    return quantity;
+  }
+
+  /**
+   * Determines whether this order should be triggered
+   * based on the current market price.
+   *
+   * @param currentPrice the current market price of the stock
+   * @return true if the order should be executed, false otherwise
+   */
+  public abstract boolean shouldTrigger(BigDecimal currentPrice);
+
+  /**
+   * Executes the order on the given exchange.
+   * Called when {@link #shouldTrigger(BigDecimal)} returns true.
+   *
+   * @param exchange the exchange on which to execute the order
+   */
+  public abstract void execute(Exchange exchange);
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitSellOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitSellOrder.java
@@ -8,8 +8,22 @@ import java.math.BigDecimal;
 
 public class LimitSellOrder extends LimitOrder{
 
-  public LimitSellOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity) {
-    super(stock, player, targetPrice, quantity);
+  /**
+   * Creates a new sell order with an explicit expiry week.
+   */
+  public LimitSellOrder(Stock stock, Player player, BigDecimal targetPrice,
+                       BigDecimal quantity, int currentWeek, int expiryWeek) {
+    super(stock, player, targetPrice, quantity, currentWeek, expiryWeek);
+  }
+
+  /**
+   * Creates a new sell order with the default duration of
+   * {@link LimitOrder#DEFAULT_DURATION_WEEKS} weeks.
+   */
+  public LimitSellOrder(Stock stock, Player player, BigDecimal targetPrice,
+                       BigDecimal quantity, int currentWeek) {
+    this(stock, player, targetPrice, quantity, currentWeek,
+        currentWeek + DEFAULT_DURATION_WEEKS);
   }
 
   @Override
@@ -19,6 +33,6 @@ public class LimitSellOrder extends LimitOrder{
 
   @Override
   public void execute(Exchange exchange) {
-
+    exchange.sellQuantity(getStock(), getQuantity(), getPlayer());
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitSellOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/LimitSellOrder.java
@@ -1,0 +1,24 @@
+package edu.ntnu.idatt2003.gruppe50.domain.trade.order;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
+
+import java.math.BigDecimal;
+
+public class LimitSellOrder extends LimitOrder{
+
+  public LimitSellOrder(Stock stock, Player player, BigDecimal targetPrice, BigDecimal quantity) {
+    super(stock, player, targetPrice, quantity);
+  }
+
+  @Override
+  public boolean shouldTrigger(BigDecimal currentPrice) {
+    return getTargetPrice().compareTo(currentPrice) <= 0;
+  }
+
+  @Override
+  public void execute(Exchange exchange) {
+
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/StopLossOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/trade/order/StopLossOrder.java
@@ -1,0 +1,47 @@
+package edu.ntnu.idatt2003.gruppe50.domain.trade.order;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
+import java.math.BigDecimal;
+
+public class StopLossOrder extends LimitOrder {
+
+  /**
+   * Creates a new stop-loss order with an explicit expiry week.
+   */
+  public StopLossOrder(
+      Stock stock,
+      Player player,
+      BigDecimal targetPrice,
+      BigDecimal quantity,
+      int currentWeek,
+      int expiryWeek
+  ) {
+    super(stock, player, targetPrice, quantity, currentWeek, expiryWeek);
+  }
+
+  /**
+   * Creates a new stop-loss order with the default duration.
+   */
+  public StopLossOrder(
+      Stock stock,
+      Player player,
+      BigDecimal targetPrice,
+      BigDecimal quantity,
+      int currentWeek
+  ) {
+    this(stock, player, targetPrice, quantity, currentWeek,
+        currentWeek + DEFAULT_DURATION_WEEKS);
+  }
+
+  @Override
+  public boolean shouldTrigger(BigDecimal currentPrice) {
+    return currentPrice.compareTo(getTargetPrice()) <= 0;
+  }
+
+  @Override
+  public void execute(Exchange exchange) {
+    exchange.sellQuantity(getStock(), getQuantity(), getPlayer());
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/GameController.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/GameController.java
@@ -29,8 +29,8 @@ public final class GameController {
     buyShare.execute(new BuyShareUseCase.Request(gameId, symbol, quantity));
   }
 
-  public void sell(UUID shareId) {
-    sellShare.execute(new SellShareUseCase.Request(gameId, shareId));
+  public void sell(String symbol, BigDecimal quantity) {
+    sellShare.execute(new SellShareUseCase.Request(gameId, symbol, quantity));
   }
 
   public void advanceWeek() {

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/OrdersController.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/OrdersController.java
@@ -1,0 +1,41 @@
+package edu.ntnu.idatt2003.gruppe50.ui.controller;
+
+import edu.ntnu.idatt2003.gruppe50.application.query.GetPendingOrdersUseCase;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitBuyOrder;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
+import edu.ntnu.idatt2003.gruppe50.ui.model.OrderData;
+import java.util.List;
+import java.util.UUID;
+
+public class OrdersController {
+
+  private final UUID gameId;
+  private final GetPendingOrdersUseCase getPendingOrders;
+
+  public OrdersController(UUID gameId, GetPendingOrdersUseCase getPendingOrders) {
+    this.gameId = gameId;
+    this.getPendingOrders = getPendingOrders;
+  }
+
+  public List<OrderData> getPendingOrders() {
+    return getPendingOrders.execute(gameId).stream()
+        .map(this::toOrderData)
+        .toList();
+  }
+
+  private OrderData toOrderData(LimitOrder order) {
+    String type = order instanceof LimitBuyOrder
+        ? "Buy limit"
+        : "Sell limit";
+
+    return new OrderData(
+        type,
+        order.getStock().getSymbol(),
+        order.getStock().getCompany(),
+        order.getQuantity(),
+        order.getTargetPrice(),
+        order.getCreatedWeek(),
+        order.getExpiryWeek()
+    );
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/OrdersController.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/OrdersController.java
@@ -3,6 +3,8 @@ package edu.ntnu.idatt2003.gruppe50.ui.controller;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPendingOrdersUseCase;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitBuyOrder;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitSellOrder;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.StopLossOrder;
 import edu.ntnu.idatt2003.gruppe50.ui.model.OrderData;
 import java.util.List;
 import java.util.UUID;
@@ -24,12 +26,8 @@ public class OrdersController {
   }
 
   private OrderData toOrderData(LimitOrder order) {
-    String type = order instanceof LimitBuyOrder
-        ? "Buy limit"
-        : "Sell limit";
-
     return new OrderData(
-        type,
+        getOrderTypeLabel(order),
         order.getStock().getSymbol(),
         order.getStock().getCompany(),
         order.getQuantity(),
@@ -37,5 +35,21 @@ public class OrdersController {
         order.getCreatedWeek(),
         order.getExpiryWeek()
     );
+  }
+
+  private String getOrderTypeLabel(LimitOrder order) {
+    if (order instanceof LimitBuyOrder) {
+      return "Buy at target price";
+    }
+
+    if (order instanceof LimitSellOrder) {
+      return "Sell at target price";
+    }
+
+    if (order instanceof StopLossOrder) {
+      return "Stop loss";
+    }
+
+    return "Unknown order";
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/StockDetailController.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/StockDetailController.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.gruppe50.ui.controller;
 import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.PlaceBuyLimitOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.PlaceSellLimitOrderUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceStopLossOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPortfolioUseCase;
 import edu.ntnu.idatt2003.gruppe50.ui.model.ShareData;
@@ -21,8 +22,9 @@ public class StockDetailController {
   private final GetPortfolioUseCase getPortfolio;
   private final PlaceBuyLimitOrderUseCase placeBuyLimitOrder;
   private final PlaceSellLimitOrderUseCase placeSellLimitOrder;
+  private final PlaceStopLossOrderUseCase placeStopLossOrder;
 
-  public StockDetailController(UUID gameId, BuyShareUseCase buyShare, SellShareUseCase sellShare, PortfolioQueryController portfolioQueryController, GetPortfolioUseCase getPortfolio, PlaceBuyLimitOrderUseCase placeBuyLimitOrderUseCase, PlaceSellLimitOrderUseCase sellLimitOrder) {
+  public StockDetailController(UUID gameId, BuyShareUseCase buyShare, SellShareUseCase sellShare, PortfolioQueryController portfolioQueryController, GetPortfolioUseCase getPortfolio, PlaceBuyLimitOrderUseCase placeBuyLimitOrderUseCase, PlaceSellLimitOrderUseCase sellLimitOrder, PlaceStopLossOrderUseCase placeStopLossOrder) {
     this.gameId = gameId;
     this.buyShare = buyShare;
     this.sellShare = sellShare;
@@ -30,6 +32,7 @@ public class StockDetailController {
     this.getPortfolio = getPortfolio;
     this.placeBuyLimitOrder = placeBuyLimitOrderUseCase;
     this.placeSellLimitOrder = sellLimitOrder;
+    this.placeStopLossOrder = placeStopLossOrder;
   }
 
   public Optional<ShareData> getHolding(String symbol) {
@@ -63,7 +66,9 @@ public class StockDetailController {
   }
 
   public void placeLimitOrder(DraftOrder draftOrder) {
-    if (draftOrder.side() == OrderFormView.Side.BUY) {
+    if (draftOrder.side() == OrderFormView.Side.BUY
+        && draftOrder.orderType() == OrderFormView.OrderType.TARGET_PRICE) {
+
       placeBuyLimitOrder.execute(new PlaceBuyLimitOrderUseCase.Request(
           gameId,
           draftOrder.stock().getSymbol(),
@@ -71,7 +76,12 @@ public class StockDetailController {
           draftOrder.targetPrice(),
           draftOrder.duration()
       ));
-    } else {
+      return;
+    }
+
+    if (draftOrder.side() == OrderFormView.Side.SELL
+        && draftOrder.orderType() == OrderFormView.OrderType.TARGET_PRICE) {
+
       placeSellLimitOrder.execute(new PlaceSellLimitOrderUseCase.Request(
           gameId,
           draftOrder.stock().getSymbol(),
@@ -79,6 +89,22 @@ public class StockDetailController {
           draftOrder.targetPrice(),
           draftOrder.duration()
       ));
+      return;
     }
+
+    if (draftOrder.side() == OrderFormView.Side.SELL
+        && draftOrder.orderType() == OrderFormView.OrderType.STOP_LOSS) {
+
+      placeStopLossOrder.execute(new PlaceStopLossOrderUseCase.Request(
+          gameId,
+          draftOrder.stock().getSymbol(),
+          draftOrder.quantity(),
+          draftOrder.targetPrice(),
+          draftOrder.duration()
+      ));
+      return;
+    }
+
+    throw new IllegalArgumentException("Unsupported order type");
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/StockDetailController.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/controller/StockDetailController.java
@@ -1,13 +1,14 @@
 package edu.ntnu.idatt2003.gruppe50.ui.controller;
 
 import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
-
-import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceBuyLimitOrderUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceSellLimitOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPortfolioUseCase;
-import edu.ntnu.idatt2003.gruppe50.application.query.ShareDto;
 import edu.ntnu.idatt2003.gruppe50.ui.model.ShareData;
-import java.math.BigDecimal;
+import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.DraftOrder;
+import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.OrderFormView;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,39 +19,66 @@ public class StockDetailController {
   private final SellShareUseCase sellShare;
   private final PortfolioQueryController portfolioQueryController;
   private final GetPortfolioUseCase getPortfolio;
+  private final PlaceBuyLimitOrderUseCase placeBuyLimitOrder;
+  private final PlaceSellLimitOrderUseCase placeSellLimitOrder;
 
-  public StockDetailController(UUID gameId, BuyShareUseCase buyShare, SellShareUseCase sellShare, PortfolioQueryController portfolioQueryController, GetPortfolioUseCase getPortfolio) {
+  public StockDetailController(UUID gameId, BuyShareUseCase buyShare, SellShareUseCase sellShare, PortfolioQueryController portfolioQueryController, GetPortfolioUseCase getPortfolio, PlaceBuyLimitOrderUseCase placeBuyLimitOrderUseCase, PlaceSellLimitOrderUseCase sellLimitOrder) {
     this.gameId = gameId;
     this.buyShare = buyShare;
     this.sellShare = sellShare;
     this.portfolioQueryController = portfolioQueryController;
     this.getPortfolio = getPortfolio;
+    this.placeBuyLimitOrder = placeBuyLimitOrderUseCase;
+    this.placeSellLimitOrder = sellLimitOrder;
   }
-
-  public void buy(String symbol, BigDecimal quantity) {
-    buyShare.execute(new BuyShareUseCase.Request(gameId, symbol, quantity));
-  }
-
-  /** Selger ett (det første) lot brukeren eier av gitt symbol. */
-  public Optional<UUID> sellOneOf(String symbol) {
-    GetPortfolioUseCase.Response res =
-        getPortfolio.execute(new GetPortfolioUseCase.Request(gameId));
-
-    Optional<UUID> shareId = res.shares().stream()
-        .filter(s -> s.symbol().equalsIgnoreCase(symbol))
-        .map(ShareDto::shareId)
-        .findFirst();
-
-    shareId.ifPresent(id ->
-        sellShare.execute(new SellShareUseCase.Request(gameId, id))
-    );
-    return shareId;
-  }
-
 
   public Optional<ShareData> getHolding(String symbol) {
     return portfolioQueryController.getPortfolio().shares().stream()
         .filter(s -> s.symbol().equals(symbol))
         .findFirst();
+  }
+
+  public void placeOrder(DraftOrder draftOrder) {
+    if (draftOrder.isLimit()) {
+      placeLimitOrder(draftOrder);
+    } else {
+      placeMarketOrder(draftOrder);
+    }
+  }
+
+  public void placeMarketOrder(DraftOrder draftOrder) {
+    if (draftOrder.side() == OrderFormView.Side.BUY) {
+      buyShare.execute(new BuyShareUseCase.Request(
+          gameId,
+          draftOrder.stock().getSymbol(),
+          draftOrder.quantity()
+      ));
+    } else {
+      sellShare.execute(new SellShareUseCase.Request(
+          gameId,
+          draftOrder.stock().getSymbol(),
+          draftOrder.quantity()
+      ));
+    }
+  }
+
+  public void placeLimitOrder(DraftOrder draftOrder) {
+    if (draftOrder.side() == OrderFormView.Side.BUY) {
+      placeBuyLimitOrder.execute(new PlaceBuyLimitOrderUseCase.Request(
+          gameId,
+          draftOrder.stock().getSymbol(),
+          draftOrder.quantity(),
+          draftOrder.targetPrice(),
+          draftOrder.duration()
+      ));
+    } else {
+      placeSellLimitOrder.execute(new PlaceSellLimitOrderUseCase.Request(
+          gameId,
+          draftOrder.stock().getSymbol(),
+          draftOrder.quantity(),
+          draftOrder.targetPrice(),
+          draftOrder.duration()
+      ));
+    }
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/model/OrderData.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/model/OrderData.java
@@ -1,0 +1,14 @@
+package edu.ntnu.idatt2003.gruppe50.ui.model;
+
+import java.math.BigDecimal;
+
+public record OrderData(
+    String type,
+    String symbol,
+    String company,
+    BigDecimal quantity,
+    BigDecimal targetPrice,
+    int createdWeek,
+    int expiryWeek
+) {
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/DraftOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/DraftOrder.java
@@ -1,0 +1,33 @@
+package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.shared.Validate;
+
+import java.math.BigDecimal;
+
+public record DraftOrder(
+    OrderFormView.Side side,
+    Stock stock,
+    BigDecimal quantity,
+    BigDecimal targetPrice,
+    Integer duration
+) {
+  public DraftOrder {
+    Validate.notNull(side, "Side");
+    Validate.notNull(stock, "Stock");
+    Validate.positive(quantity, "Quantity");
+
+    if (targetPrice == null && duration != null) {
+      throw new IllegalArgumentException("Duration is only allowed for limit orders");
+    }
+
+    if (targetPrice != null) {
+      Validate.positive(targetPrice, "Target Price");
+      Validate.positiveInt(duration, "Duration");
+    }
+  }
+
+  public boolean isLimit() {
+    return targetPrice != null;
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/DraftOrder.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/DraftOrder.java
@@ -2,11 +2,11 @@ package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
 
 import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
-
 import java.math.BigDecimal;
 
 public record DraftOrder(
     OrderFormView.Side side,
+    OrderFormView.OrderType orderType,
     Stock stock,
     BigDecimal quantity,
     BigDecimal targetPrice,
@@ -14,20 +14,25 @@ public record DraftOrder(
 ) {
   public DraftOrder {
     Validate.notNull(side, "Side");
+    Validate.notNull(orderType, "Order type");
     Validate.notNull(stock, "Stock");
     Validate.positive(quantity, "Quantity");
 
-    if (targetPrice == null && duration != null) {
-      throw new IllegalArgumentException("Duration is only allowed for limit orders");
-    }
-
-    if (targetPrice != null) {
+    if (orderType == OrderFormView.OrderType.MARKET) {
+      if (targetPrice != null || duration != null) {
+        throw new IllegalArgumentException("Market orders cannot have target price or duration");
+      }
+    } else {
       Validate.positive(targetPrice, "Target Price");
       Validate.positiveInt(duration, "Duration");
     }
   }
 
+  public boolean isPendingOrder() {
+    return orderType != OrderFormView.OrderType.MARKET;
+  }
+
   public boolean isLimit() {
-    return targetPrice != null;
+    return isPendingOrder();
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderConfirmationView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderConfirmationView.java
@@ -1,0 +1,99 @@
+package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
+
+import java.util.function.Consumer;
+import edu.ntnu.idatt2003.gruppe50.shared.MoneyFormat;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+public class OrderConfirmationView extends VBox {
+
+  private final OrderPreview preview;
+  private final Runnable onBack;
+  private final Consumer<DraftOrder> onConfirm;
+
+  public OrderConfirmationView(OrderPreview preview, Runnable onBack, Consumer<DraftOrder> onConfirm) {
+    this.preview = preview;
+    this.onBack = onBack;
+    this.onConfirm = onConfirm;
+
+    setSpacing(15);
+
+    getChildren().setAll(buildTitle(), buildDetails(), buildTotal(), buildActions());
+  }
+
+  private Label buildTitle() {
+    String action = preview.draftOrder().side() == OrderFormView.Side.BUY ? "buy" : "sell";
+
+    Label title = new Label("Confirm " + action);
+    title.getStyleClass().add("popup-title");
+    return title;
+  }
+
+  private VBox buildDetails() {
+    DraftOrder draftOrder = preview.draftOrder();
+
+    String action = draftOrder.side() == OrderFormView.Side.BUY ? "buy" : "sell";
+    String orderTypeLabel = draftOrder.isLimit()
+        ? "Limit " + action
+        : "Market " + action;
+
+    VBox details = new VBox(8,
+        row("Stock", draftOrder.stock().getCompany()),
+        row("Order type", orderTypeLabel),
+        row("Quantity", draftOrder.quantity().toString()),
+        row("Price", MoneyFormat.formatCurrency(preview.price())),
+        row("Subtotal", MoneyFormat.formatCurrency(preview.subtotal())),
+        row("Commission", MoneyFormat.formatCurrency(preview.commission()))
+    );
+
+    if (draftOrder.side() == OrderFormView.Side.SELL) {
+      details.getChildren().add(row("Tax", MoneyFormat.formatCurrency(preview.tax())));
+    }
+
+    if (preview.isLimit()) {
+      details.getChildren().add(row("Duration", draftOrder.duration() + " weeks")
+//                                row("Expires, Week " + preview.expirationWeek()
+                                  );
+    }
+
+    return details;
+  }
+
+  private Label buildTotal() {
+    Label totalLabel = new Label("Estimated total: " + MoneyFormat.formatCurrency(preview.total()));
+    totalLabel.getStyleClass().add("popup-total");
+    return totalLabel;
+  }
+
+  private HBox buildActions() {
+    Button backBtn = new Button("Back");
+    backBtn.setOnAction(e -> onBack.run());
+
+    Button confirmBtn = new Button("Confirm");
+    confirmBtn.getStyleClass().add("primary");
+    confirmBtn.setOnAction(e -> onConfirm.accept(preview.draftOrder()));
+
+    HBox actions = new HBox(10, backBtn, confirmBtn);
+    actions.setAlignment(Pos.CENTER_RIGHT);
+    return actions;
+  }
+
+  private HBox row(String label, String value) {
+    Label l = new Label(label);
+    l.getStyleClass().add("detail-label");
+
+    Label v = new Label(value);
+    v.getStyleClass().add("detail-value");
+
+    Region spacer = new Region();
+    HBox.setHgrow(spacer, Priority.ALWAYS);
+
+    return new HBox(l, spacer, v);
+  }
+
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderConfirmationView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderConfirmationView.java
@@ -37,10 +37,7 @@ public class OrderConfirmationView extends VBox {
   private VBox buildDetails() {
     DraftOrder draftOrder = preview.draftOrder();
 
-    String action = draftOrder.side() == OrderFormView.Side.BUY ? "buy" : "sell";
-    String orderTypeLabel = draftOrder.isLimit()
-        ? "Limit " + action
-        : "Market " + action;
+    String orderTypeLabel = getOrderTypeLabel(draftOrder);
 
     VBox details = new VBox(8,
         row("Stock", draftOrder.stock().getCompany()),
@@ -96,4 +93,32 @@ public class OrderConfirmationView extends VBox {
     return new HBox(l, spacer, v);
   }
 
+  private String getOrderTypeLabel(DraftOrder draftOrder) {
+    if (draftOrder.side() == OrderFormView.Side.BUY
+        && draftOrder.orderType() == OrderFormView.OrderType.MARKET) {
+      return "Buy now";
+    }
+
+    if (draftOrder.side() == OrderFormView.Side.BUY
+        && draftOrder.orderType() == OrderFormView.OrderType.TARGET_PRICE) {
+      return "Buy at target price";
+    }
+
+    if (draftOrder.side() == OrderFormView.Side.SELL
+        && draftOrder.orderType() == OrderFormView.OrderType.MARKET) {
+      return "Sell now";
+    }
+
+    if (draftOrder.side() == OrderFormView.Side.SELL
+        && draftOrder.orderType() == OrderFormView.OrderType.TARGET_PRICE) {
+      return "Sell at target price";
+    }
+
+    if (draftOrder.side() == OrderFormView.Side.SELL
+        && draftOrder.orderType() == OrderFormView.OrderType.STOP_LOSS) {
+      return "Stop loss";
+    }
+
+    return "Unknown order";
+  }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderFormView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderFormView.java
@@ -14,19 +14,9 @@ public class OrderFormView extends StackPane {
   public enum Side { BUY, SELL }
 
   public enum OrderType {
-    MARKET("Market order"),
-    LIMIT("Limit order");
-
-    private final String label;
-
-    OrderType(String label) {
-      this.label = label;
-    }
-
-    @Override
-    public String toString() {
-      return label;
-    }
+    MARKET,
+    TARGET_PRICE,
+    STOP_LOSS
   }
 
   private final Side side;

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderFormView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderFormView.java
@@ -1,0 +1,88 @@
+package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+
+import java.util.function.Consumer;
+
+public class OrderFormView extends StackPane {
+
+  public enum Side { BUY, SELL }
+
+  public enum OrderType {
+    MARKET("Market order"),
+    LIMIT("Limit order");
+
+    private final String label;
+
+    OrderType(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return label;
+    }
+  }
+
+  private final Side side;
+  private final Stock stock;
+  private final Runnable onClose;
+  private final Consumer<DraftOrder> onConfirmOrder;
+  private final VBox card;
+
+  public OrderFormView(Side side, Stock stock, Runnable onClose, Consumer<DraftOrder> onConfirmOrder) {
+    this.side = side;
+    this.stock = stock;
+    this.onClose = onClose;
+    this.onConfirmOrder = onConfirmOrder;
+
+    Region backdrop = new Region();
+    backdrop.getStyleClass().add("modal-backdrop");
+    backdrop.setOnMouseClicked(e -> onClose.run());
+
+    this.card = new VBox(15);
+    card.getStyleClass().add("place-order-popup");
+    card.setMaxWidth(420);
+    card.setMaxHeight(Region.USE_PREF_SIZE);
+
+    getChildren().addAll(backdrop, card);
+
+    StackPane.setAlignment(card, Pos.TOP_CENTER);
+    StackPane.setMargin(card, new Insets(80, 0, 0, 0));
+
+    showInput();
+  }
+
+  private void showInput() {
+    OrderInputView inputView = new OrderInputView(
+        side,
+        stock,
+        this::showConfirmation,
+        onClose
+    );
+
+    card.getChildren().setAll(inputView);
+  }
+
+  private void showConfirmation(DraftOrder draftOrder) {
+    OrderPreview preview = OrderPreview.from(draftOrder);
+
+    OrderConfirmationView confirmationView = new OrderConfirmationView(
+        preview,
+        this::showInput,
+        this::confirmOrder
+    );
+
+    card.getChildren().setAll(confirmationView);
+  }
+
+  private void confirmOrder(DraftOrder draftOrder) {
+    onConfirmOrder.accept(draftOrder);
+    onClose.run();
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderInputView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderInputView.java
@@ -1,0 +1,158 @@
+package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
+
+import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.order.LimitOrder;
+import javafx.collections.FXCollections;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+import java.math.BigDecimal;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+public class OrderInputView extends VBox{
+
+  private final OrderFormView.Side side;
+  private final Stock stock;
+  private final Consumer<DraftOrder> onNext;
+  private final Runnable onCancel;
+
+  private final ChoiceBox<OrderFormView.OrderType> orderTypeBox = new ChoiceBox<>();
+  private final TextField quantityField = new TextField();
+  private final TextField targetPriceField = new TextField();
+  private final ChoiceBox<Integer> durationBox = new ChoiceBox<>();
+  private final VBox limitFieldsBox = new VBox(10);
+  private final Label errorLabel = new Label();
+
+  public OrderInputView(OrderFormView.Side side, Stock stock, Consumer<DraftOrder> onNext, Runnable onCancel) {
+    this.side = side;
+    this.stock = stock;
+    this.onNext = onNext;
+    this.onCancel = onCancel;
+
+    setSpacing(15);
+
+    Label title = new Label((side == OrderFormView.Side.BUY ? "Buy" : "Sell") + " " + stock.getCompany());
+    title.getStyleClass().add("popup-title");
+
+    errorLabel.getStyleClass().add("popup-error");
+    errorLabel.setVisible(false);
+    errorLabel.setManaged(false);
+
+    getChildren().setAll(
+        title,
+        buildForm(),
+        errorLabel,
+        buildFormActions()
+    );
+  }
+
+  private VBox buildForm() {
+    orderTypeBox.setItems(FXCollections.observableArrayList(OrderFormView.OrderType.values()));
+    orderTypeBox.setValue(OrderFormView.OrderType.MARKET);
+    orderTypeBox.setMaxWidth(Double.MAX_VALUE);
+    orderTypeBox.valueProperty().addListener((obs, oldVal, newVal) -> updateLimitVisibility());
+
+    quantityField.setPromptText("Quantity");
+    targetPriceField.setPromptText("Target price (kr)");
+
+    durationBox.setItems(FXCollections.observableArrayList(
+        IntStream.rangeClosed(1, LimitOrder.MAX_DURATION_WEEKS).boxed().toList()));
+    durationBox.setValue(LimitOrder.DEFAULT_DURATION_WEEKS);
+    durationBox.setMaxWidth(Double.MAX_VALUE);
+
+    limitFieldsBox.getChildren().setAll(
+        new Label("Target price"), targetPriceField,
+        new Label("Duration (weeks)"), durationBox
+    );
+    updateLimitVisibility();
+
+    return new VBox(10,
+        new Label("Order type"), orderTypeBox,
+        new Label("Quantity"), quantityField,
+        limitFieldsBox
+    );
+  }
+
+  private HBox buildFormActions() {
+    Button cancelBtn = new Button("Cancel");
+    cancelBtn.setOnAction(e -> onCancel.run());
+
+    Button nextBtn = new Button("Next");
+    nextBtn.getStyleClass().add("primary");
+    nextBtn.setOnAction(e -> handleNext());
+
+    HBox actions = new HBox(10, cancelBtn, nextBtn);
+    actions.setAlignment(Pos.CENTER_RIGHT);
+    return actions;
+  }
+
+  private void updateLimitVisibility() {
+    boolean isLimit = orderTypeBox.getValue() == OrderFormView.OrderType.LIMIT;
+    limitFieldsBox.setVisible(isLimit);
+    limitFieldsBox.setManaged(isLimit);
+  }
+
+  private BigDecimal parseQuantity() {
+    String text = quantityField.getText().trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException("Quantity is required");
+    }
+    try {
+      BigDecimal quantity = new BigDecimal(text);
+      if (quantity.compareTo(BigDecimal.ZERO) <= 0) {
+        throw new IllegalArgumentException("Quantity must be positive");
+      }
+      return quantity;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Quantity must be a number");
+    }
+  }
+
+  private BigDecimal parseTargetPrice() {
+    String text = targetPriceField.getText().trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException("Target price is required");
+    }
+    try {
+      BigDecimal price = new BigDecimal(text);
+      if (price.compareTo(BigDecimal.ZERO) <= 0) {
+        throw new IllegalArgumentException("Target price must be positive");
+      }
+      return price;
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Target price must be a number");
+    }
+  }
+
+  private void handleNext() {
+    try {
+      BigDecimal quantity = parseQuantity();
+      DraftOrder draftOrder;
+
+      if (orderTypeBox.getValue() == OrderFormView.OrderType.MARKET) {
+        draftOrder = new DraftOrder(side, stock, quantity, null, null);
+      } else {
+        BigDecimal targetPrice = parseTargetPrice();
+        int duration = durationBox.getValue();
+        draftOrder = new DraftOrder(side, stock, quantity, targetPrice, duration);
+      }
+
+      onNext.accept(draftOrder);
+
+    } catch (IllegalArgumentException ex) {
+      showError(ex.getMessage());
+    }
+  }
+
+  private void showError(String message) {
+    errorLabel.setText(message);
+    errorLabel.setVisible(true);
+    errorLabel.setManaged(true);
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderInputView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderInputView.java
@@ -10,6 +10,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.util.StringConverter;
 
 import java.math.BigDecimal;
 import java.util.function.Consumer;
@@ -53,10 +54,40 @@ public class OrderInputView extends VBox{
   }
 
   private VBox buildForm() {
-    orderTypeBox.setItems(FXCollections.observableArrayList(OrderFormView.OrderType.values()));
+    if (side == OrderFormView.Side.BUY) {
+      orderTypeBox.setItems(FXCollections.observableArrayList(
+          OrderFormView.OrderType.MARKET,
+          OrderFormView.OrderType.TARGET_PRICE
+      ));
+    } else {
+      orderTypeBox.setItems(FXCollections.observableArrayList(
+          OrderFormView.OrderType.MARKET,
+          OrderFormView.OrderType.TARGET_PRICE,
+          OrderFormView.OrderType.STOP_LOSS
+      ));
+    }
+
     orderTypeBox.setValue(OrderFormView.OrderType.MARKET);
+
     orderTypeBox.setMaxWidth(Double.MAX_VALUE);
-    orderTypeBox.valueProperty().addListener((obs, oldVal, newVal) -> updateLimitVisibility());
+    orderTypeBox.valueProperty().addListener(
+        (obs, oldVal, newVal) -> updateTargetFieldsVisibility()
+    );
+    orderTypeBox.setConverter(new StringConverter<>() {
+      @Override
+      public String toString(OrderFormView.OrderType orderType) {
+        if (orderType == null) {
+          return "";
+        }
+
+        return getOrderTypeLabel(orderType);
+      }
+
+      @Override
+      public OrderFormView.OrderType fromString(String string) {
+        return null;
+      }
+    });
 
     quantityField.setPromptText("Quantity");
     targetPriceField.setPromptText("Target price (kr)");
@@ -70,7 +101,7 @@ public class OrderInputView extends VBox{
         new Label("Target price"), targetPriceField,
         new Label("Duration (weeks)"), durationBox
     );
-    updateLimitVisibility();
+    updateTargetFieldsVisibility();
 
     return new VBox(10,
         new Label("Order type"), orderTypeBox,
@@ -92,10 +123,12 @@ public class OrderInputView extends VBox{
     return actions;
   }
 
-  private void updateLimitVisibility() {
-    boolean isLimit = orderTypeBox.getValue() == OrderFormView.OrderType.LIMIT;
-    limitFieldsBox.setVisible(isLimit);
-    limitFieldsBox.setManaged(isLimit);
+  private void updateTargetFieldsVisibility() {
+    boolean showTargetFields =
+        orderTypeBox.getValue() != OrderFormView.OrderType.MARKET;
+
+    limitFieldsBox.setVisible(showTargetFields);
+    limitFieldsBox.setManaged(showTargetFields);
   }
 
   private BigDecimal parseQuantity() {
@@ -133,14 +166,30 @@ public class OrderInputView extends VBox{
   private void handleNext() {
     try {
       BigDecimal quantity = parseQuantity();
+
       DraftOrder draftOrder;
 
       if (orderTypeBox.getValue() == OrderFormView.OrderType.MARKET) {
-        draftOrder = new DraftOrder(side, stock, quantity, null, null);
+        draftOrder = new DraftOrder(
+            side,
+            orderTypeBox.getValue(),
+            stock,
+            quantity,
+            null,
+            null
+        );
       } else {
         BigDecimal targetPrice = parseTargetPrice();
-        int duration = durationBox.getValue();
-        draftOrder = new DraftOrder(side, stock, quantity, targetPrice, duration);
+        Integer duration = durationBox.getValue();
+
+        draftOrder = new DraftOrder(
+            side,
+            orderTypeBox.getValue(),
+            stock,
+            quantity,
+            targetPrice,
+            duration
+        );
       }
 
       onNext.accept(draftOrder);
@@ -154,5 +203,33 @@ public class OrderInputView extends VBox{
     errorLabel.setText(message);
     errorLabel.setVisible(true);
     errorLabel.setManaged(true);
+  }
+
+  private String getOrderTypeLabel(OrderFormView.OrderType orderType) {
+    if (side == OrderFormView.Side.BUY) {
+      if (orderType == OrderFormView.OrderType.MARKET) {
+        return "Buy now";
+      }
+
+      if (orderType == OrderFormView.OrderType.TARGET_PRICE) {
+        return "Buy at target price";
+      }
+    }
+
+    if (side == OrderFormView.Side.SELL) {
+      if (orderType == OrderFormView.OrderType.MARKET) {
+        return "Sell now";
+      }
+
+      if (orderType == OrderFormView.OrderType.TARGET_PRICE) {
+        return "Sell at target price";
+      }
+
+      if (orderType == OrderFormView.OrderType.STOP_LOSS) {
+        return "Stop loss";
+      }
+    }
+
+    return orderType.toString();
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderPreview.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/OrderPreview.java
@@ -1,0 +1,56 @@
+package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
+
+import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.PurchaseCalculator;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.SaleCalculator;
+import java.math.BigDecimal;
+
+public record OrderPreview(DraftOrder draftOrder, BigDecimal price, BigDecimal subtotal, BigDecimal commission, BigDecimal tax, BigDecimal total) {
+
+  private static final int PREVIEW_WEEK = 1;
+
+  public static OrderPreview from(DraftOrder draftOrder) {
+    BigDecimal price = draftOrder.isLimit()
+        ? draftOrder.targetPrice()
+        : draftOrder.stock().getSalesPrice();
+
+    Share previewShare = new Share(
+        draftOrder.stock(),
+        draftOrder.quantity(),
+        price,
+        PREVIEW_WEEK
+    );
+
+    BigDecimal subtotal = price.multiply(draftOrder.quantity());
+    BigDecimal commission;
+    BigDecimal tax = BigDecimal.ZERO;
+    BigDecimal total;
+
+    if (draftOrder.side() == OrderFormView.Side.BUY) {
+      PurchaseCalculator calculator = new PurchaseCalculator(previewShare);
+
+      commission = calculator.calculateCommission();
+      total = calculator.calculateTotal();
+
+    } else {
+      SaleCalculator calculator = new SaleCalculator(previewShare);
+
+      commission = calculator.calculateCommission();
+      tax = calculator.calculateTax();
+      total = calculator.calculateTotal();
+    }
+
+    return new OrderPreview(
+        draftOrder,
+        price,
+        subtotal,
+        commission,
+        tax,
+        total
+    );
+  }
+
+  public boolean isLimit() {
+    return draftOrder().isLimit();
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/navigation/PageId.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/navigation/PageId.java
@@ -4,7 +4,8 @@ public enum PageId {
   DASHBOARD("Dashboard"),
   MARKET("Market"),
   PORTFOLIO("Portfolio"),
-  TRANSACTIONS("Transactions");
+  TRANSACTIONS("Transactions"),
+  ORDERS("Orders");
 
   private final String label;
 

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
@@ -3,6 +3,7 @@ package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
 import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.PlaceBuyLimitOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.PlaceSellLimitOrderUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceStopLossOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPortfolioUseCase;
 import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
@@ -38,12 +39,13 @@ public class GameViewCoordinator {
   private final PlaceBuyLimitOrderUseCase buyLimitOrder;
   private final PlaceSellLimitOrderUseCase sellLimitOrder;
   private final OrdersController ordersController;
+  private final PlaceStopLossOrderUseCase stopLossOrder;
 
 
   public GameViewCoordinator(GameController gameController,
                              PortfolioQueryController portfolioQueryController, TransactionQueryController transactionQueryController,
                              BuyShareUseCase buyShare, SellShareUseCase sellShare,
-                             UUID gameId, Exchange exchange, Player player, GetPortfolioUseCase getPortfolio, PlaceBuyLimitOrderUseCase buyLimitOrder, PlaceSellLimitOrderUseCase sellLimitOrder, OrdersController ordersController) {
+                             UUID gameId, Exchange exchange, Player player, GetPortfolioUseCase getPortfolio, PlaceBuyLimitOrderUseCase buyLimitOrder, PlaceSellLimitOrderUseCase sellLimitOrder, PlaceStopLossOrderUseCase stopLossOrder, OrdersController ordersController) {
     this.transactionQueryController = transactionQueryController;
     this.sellShare = sellShare;
     this.exchange = exchange;
@@ -55,6 +57,7 @@ public class GameViewCoordinator {
     this.getPortfolio = getPortfolio;
     this.buyLimitOrder = buyLimitOrder;
     this.sellLimitOrder = sellLimitOrder;
+    this.stopLossOrder = stopLossOrder;
     this.ordersController = ordersController;
   }
 
@@ -89,7 +92,7 @@ public class GameViewCoordinator {
 
   private void navigateToStockDetail(Stock stock) {
     StockDetailController controller = new StockDetailController(
-        gameId, buyShare, sellShare, portfolioQueryController, getPortfolio, buyLimitOrder, sellLimitOrder);
+        gameId, buyShare, sellShare, portfolioQueryController, getPortfolio, buyLimitOrder, sellLimitOrder, stopLossOrder);
     StockDetailView view = new StockDetailView(
         stock, controller, () -> navManager.navigateTo(PageId.MARKET));
     navManager.show(view);

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
@@ -1,6 +1,8 @@
 package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
 
 import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceBuyLimitOrderUseCase;
+import edu.ntnu.idatt2003.gruppe50.application.command.PlaceSellLimitOrderUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.query.GetPortfolioUseCase;
 import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
@@ -8,6 +10,7 @@ import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.GameController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.MarketController;
+import edu.ntnu.idatt2003.gruppe50.ui.controller.OrdersController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.PortfolioQueryController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.StockDetailController;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.TransactionQueryController;
@@ -32,11 +35,15 @@ public class GameViewCoordinator {
   private final Player player;
   private NavigationManager navManager;
   private final GetPortfolioUseCase getPortfolio;
+  private final PlaceBuyLimitOrderUseCase buyLimitOrder;
+  private final PlaceSellLimitOrderUseCase sellLimitOrder;
+  private final OrdersController ordersController;
+
 
   public GameViewCoordinator(GameController gameController,
                              PortfolioQueryController portfolioQueryController, TransactionQueryController transactionQueryController,
                              BuyShareUseCase buyShare, SellShareUseCase sellShare,
-                             UUID gameId, Exchange exchange, Player player, GetPortfolioUseCase getPortfolio) {
+                             UUID gameId, Exchange exchange, Player player, GetPortfolioUseCase getPortfolio, PlaceBuyLimitOrderUseCase buyLimitOrder, PlaceSellLimitOrderUseCase sellLimitOrder, OrdersController ordersController) {
     this.transactionQueryController = transactionQueryController;
     this.sellShare = sellShare;
     this.exchange = exchange;
@@ -46,6 +53,9 @@ public class GameViewCoordinator {
     this.buyShare = buyShare;
     this.gameId = gameId;
     this.getPortfolio = getPortfolio;
+    this.buyLimitOrder = buyLimitOrder;
+    this.sellLimitOrder = sellLimitOrder;
+    this.ordersController = ordersController;
   }
 
   public Scene getScene() {
@@ -72,13 +82,14 @@ public class GameViewCoordinator {
     pages.put(PageId.MARKET, new MarketView(marketController));
     pages.put(PageId.PORTFOLIO, new PortfolioView(portfolioQueryController, gameController));
     pages.put(PageId.TRANSACTIONS, new TransactionsView(transactionQueryController));
+    pages.put(PageId.ORDERS, new OrdersView(ordersController));
 
     return pages;
   }
 
   private void navigateToStockDetail(Stock stock) {
     StockDetailController controller = new StockDetailController(
-        gameId, buyShare, sellShare, portfolioQueryController, getPortfolio);
+        gameId, buyShare, sellShare, portfolioQueryController, getPortfolio, buyLimitOrder, sellLimitOrder);
     StockDetailView view = new StockDetailView(
         stock, controller, () -> navManager.navigateTo(PageId.MARKET));
     navManager.show(view);

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/OrdersView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/OrdersView.java
@@ -1,0 +1,85 @@
+package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
+
+import edu.ntnu.idatt2003.gruppe50.ui.controller.OrdersController;
+import edu.ntnu.idatt2003.gruppe50.ui.model.OrderData;
+import javafx.collections.FXCollections;
+import javafx.scene.Parent;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.layout.VBox;
+
+public class OrdersView extends VBox implements Page {
+
+  private final TableView<OrderData> table = new TableView<>();
+  private final OrdersController controller;
+
+  public OrdersView(OrdersController controller) {
+    this.controller = controller;
+
+    setSpacing(16);
+    getStyleClass().add("orders-page");
+
+    Label title = new Label("Orders");
+    title.getStyleClass().add("page-title");
+
+    Label subtitle = new Label("Pending limit orders");
+    subtitle.getStyleClass().add("page-subtitle");
+
+    configureTable();
+
+    getChildren().addAll(title, subtitle, table);
+  }
+
+  @Override
+  public Parent getView() {
+    refresh();
+    return this;
+  }
+
+  private void configureTable() {
+    TableColumn<OrderData, String> typeCol = new TableColumn<>("Type");
+    typeCol.setCellValueFactory(data ->
+        new javafx.beans.property.SimpleStringProperty(data.getValue().type()));
+
+    TableColumn<OrderData, String> stockCol = new TableColumn<>("Stock");
+    stockCol.setCellValueFactory(data ->
+        new javafx.beans.property.SimpleStringProperty(data.getValue().symbol()));
+
+    TableColumn<OrderData, String> quantityCol = new TableColumn<>("Quantity");
+    quantityCol.setCellValueFactory(data ->
+        new javafx.beans.property.SimpleStringProperty(data.getValue().quantity().toString()));
+
+    TableColumn<OrderData, String> targetPriceCol = new TableColumn<>("Target price");
+    targetPriceCol.setCellValueFactory(data ->
+        new javafx.beans.property.SimpleStringProperty(data.getValue().targetPrice() + " kr"));
+
+    TableColumn<OrderData, String> createdWeekCol = new TableColumn<>("Created");
+    createdWeekCol.setCellValueFactory(data ->
+        new javafx.beans.property.SimpleStringProperty("Week " + data.getValue().createdWeek()));
+
+    TableColumn<OrderData, String> expiryWeekCol = new TableColumn<>("Expires");
+    expiryWeekCol.setCellValueFactory(data ->
+        new javafx.beans.property.SimpleStringProperty("Week " + data.getValue().expiryWeek()));
+
+    table.getColumns().setAll(
+        typeCol,
+        stockCol,
+        quantityCol,
+        targetPriceCol,
+        createdWeekCol,
+        expiryWeekCol
+    );
+
+    table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+    table.setPlaceholder(new Label("No pending orders"));
+  }
+
+  public void setOrders(java.util.List<OrderData> orders) {
+    table.setItems(FXCollections.observableArrayList(orders));
+  }
+
+  public void refresh() {
+    setOrders(controller.getPendingOrders());
+  }
+}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/StockDetailView.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/StockDetailView.java
@@ -1,28 +1,26 @@
 package edu.ntnu.idatt2003.gruppe50.ui.view.pages;
 
 import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
-import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.ui.controller.StockDetailController;
 import edu.ntnu.idatt2003.gruppe50.ui.model.ShareData;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.AreaChartView;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
-import java.util.List;
+import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.DraftOrder;
+import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.OrderFormView;
 import javafx.scene.Parent;
 import javafx.scene.chart.AreaChart;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
 
-public class StockDetailView extends VBox implements Page {
+public class StockDetailView extends StackPane implements Page {
 
   private final Stock stock;
   private final StockDetailController controller;
@@ -32,8 +30,9 @@ public class StockDetailView extends VBox implements Page {
   private final Label gavLabel = new Label();
   private final Label profitLabel = new Label();
   private final Label profitPercentLabel = new Label();
-  private final TextField quantityField = new TextField();
   private final VBox myHoldingBox = new VBox(10);
+  private final VBox content = new VBox(10);
+  private final Button sell = new Button("Sell");
 
   public StockDetailView(Stock stock, StockDetailController controller, Runnable onBack) {
     this.stock = stock;
@@ -43,12 +42,14 @@ public class StockDetailView extends VBox implements Page {
     Button backBtn = new Button("Back");
     backBtn.setOnAction(e -> onBack.run());
 
-    getChildren().addAll(
+    content.getChildren().addAll(
         backBtn,
         createHeader(),
         createStockChart(),
         createStatTiles(),
         createButtonRow());
+
+    getChildren().addAll(content);
 
     refreshHolding();
   }
@@ -94,53 +95,57 @@ public class StockDetailView extends VBox implements Page {
   }
 
   private HBox createButtonRow() {
-    quantityField.setPromptText("Quantity");
-    HBox.setHgrow(quantityField, Priority.ALWAYS);
-
     Button buy = new Button("Buy");
     buy.setMaxWidth(Double.MAX_VALUE);
     HBox.setHgrow(buy, Priority.ALWAYS);
     buy.setOnAction(e -> handleBuy());
 
-    Button sell = new Button("Sell");
     sell.setMaxWidth(Double.MAX_VALUE);
     HBox.setHgrow(sell, Priority.ALWAYS);
     sell.setOnAction(e -> handleSell());
 
-    return new HBox(10, quantityField, buy, sell);
+    return new HBox(10, buy, sell);
   }
 
   private void handleBuy() {
-    try {
-      BigDecimal quantity = new BigDecimal(quantityField.getText().trim());
-      controller.buy(stock.getSymbol(), quantity);
-      quantityField.clear();
-      refreshHolding();
-    } catch (NumberFormatException ex) {
-      // TODO: vis feilmelding til bruker
-    }
+    OrderFormView popup = new OrderFormView(
+        OrderFormView.Side.BUY,
+        stock,
+        this::closePopup,
+        this::handleConfirmedOrder
+    );
+
+    getChildren().add(popup);
   }
 
   private void handleSell() {
-    Optional<UUID> sold = controller.sellOneOf(stock.getSymbol());
-    if (sold.isEmpty()) {
-      // vis melding: "Du eier ingen aksjer av dette selskapet"
-      return;
-    }
-    refreshHolding();
+    OrderFormView popup = new OrderFormView(
+        OrderFormView.Side.SELL,
+        stock,
+        this::closePopup,
+        this::handleConfirmedOrder
+    );
+
+    getChildren().add(popup);
   }
 
-
+  private void closePopup() {
+    getChildren().removeIf(node -> node instanceof OrderFormView);
+  }
 
   private void refreshHolding() {
     Optional<ShareData> holding = controller.getHolding(stock.getSymbol());
     if (holding.isEmpty()) {
       myHoldingBox.setVisible(false);
       myHoldingBox.setManaged(false);
+      sell.setVisible(false);
+      sell.setManaged(false);
       return;
     }
     myHoldingBox.setVisible(true);
     myHoldingBox.setManaged(true);
+    sell.setVisible(true);
+    sell.setManaged(true);
 
     ShareData s = holding.get();
     quantityLabel.setText(s.quantity().toString());
@@ -163,5 +168,15 @@ public class StockDetailView extends VBox implements Page {
 
   private String formatSigned(BigDecimal value) {
     return (value.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "") + value;
+  }
+
+  private void handleConfirmedOrder(DraftOrder draftOrder) {
+    try {
+      controller.placeOrder(draftOrder);
+      closePopup();
+      refreshHolding();
+    } catch (RuntimeException ex) {
+      System.out.println(ex.getMessage());
+    }
   }
 }

--- a/src/main/resources/css/styles.css
+++ b/src/main/resources/css/styles.css
@@ -63,3 +63,89 @@
     -fx-background-color: #00E6AD;
     -fx-effect: dropshadow(gaussian, #00C89660, 20, 0.4, 0, 0);
 }
+
+.modal-backdrop {
+    -fx-background-color: rgba(0, 0, 0, 0.6);
+}
+
+.place-order-popup {
+    -fx-background-color: #2C2C2C;
+    -fx-padding: 24;
+    -fx-background-radius: 8;
+    -fx-spacing: 15;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.5), 20, 0, 0, 6);
+}
+
+.place-order-popup .label {
+    -fx-text-fill: #AAAAAA;
+    -fx-font-size: 14;
+}
+
+.place-order-popup .popup-title {
+    -fx-text-fill: #FFFFFF;
+    -fx-font-size: 20;
+    -fx-font-weight: normal;
+}
+
+.place-order-popup .text-field {
+    -fx-background-color: #1C1C1C;
+    -fx-text-fill: #E0E0E0;
+    -fx-prompt-text-fill: #6A6A6A;
+    -fx-background-radius: 4;
+    -fx-padding: 8 12;
+    -fx-font-size: 14;
+}
+
+.place-order-popup .choice-box {
+    -fx-background-color: #1C1C1C;
+    -fx-text-fill: #E0E0E0;
+    -fx-background-radius: 4;
+    -fx-padding: 4 8;
+}
+
+.place-order-popup .choice-box .label {
+    -fx-text-fill: #E0E0E0;
+}
+
+.place-order-popup .button {
+    -fx-background-color: #3A3A3A;
+    -fx-text-fill: #FFFFFF;
+    -fx-background-radius: 4;
+    -fx-padding: 8 16;
+    -fx-font-size: 14;
+    -fx-cursor: hand;
+}
+
+.place-order-popup .button:hover {
+    -fx-background-color: #4A4A4A;
+}
+
+.place-order-popup .button.primary {
+    -fx-background-color: #2D5BE3;
+}
+
+.place-order-popup .button.primary:hover {
+    -fx-background-color: #4471F0;
+}
+
+.place-order-popup .detail-label {
+    -fx-text-fill: #AAAAAA;
+    -fx-font-size: 14;
+}
+
+.place-order-popup .detail-value {
+    -fx-text-fill: #E0E0E0;
+    -fx-font-size: 14;
+}
+
+.place-order-popup .popup-total {
+    -fx-text-fill: #FFFFFF;
+    -fx-font-size: 16;
+    -fx-font-weight: bold;
+    -fx-padding: 12 0 0 0;
+}
+
+.popup-error {
+    -fx-text-fill: #E74C3C;
+    -fx-font-size: 12;
+}

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/application/SellShareUseCaseTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/application/SellShareUseCaseTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import edu.ntnu.idatt2003.gruppe50.application.command.BuyShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.application.command.SellShareUseCase;
 import edu.ntnu.idatt2003.gruppe50.domain.game.GameSession;
+import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.repository.GameSessionRepository;
 import edu.ntnu.idatt2003.gruppe50.infrastructure.repository.InMemoryGameSessionRepository;
 import java.math.BigDecimal;
@@ -36,12 +37,18 @@ public class SellShareUseCaseTest {
   @Test
   void execute_validRequest_sellsShare() {
     buyShare.execute(new BuyShareUseCase.Request(session.getGameId(), "AAPL", bd(2)));
-    GameSession afterBuy = repository.findById(session.getGameId()).orElseThrow();
-    UUID shareId = afterBuy.getPlayer().getPortfolio().getShares().getFirst().getShareId();
 
-    sellShare.execute(new SellShareUseCase.Request(session.getGameId(), shareId));
+    GameSession afterBuy = repository.findById(session.getGameId()).orElseThrow();
+    Share share = afterBuy.getPlayer().getPortfolio().getShares().getFirst();
+
+    sellShare.execute(new SellShareUseCase.Request(
+        session.getGameId(),
+        share.getStock().getSymbol(),
+        share.getQuantity()
+    ));
 
     GameSession repositorySession = repository.findById(session.getGameId()).orElseThrow();
+
     assertEquals(0, repositorySession.getPlayer().getPortfolio().getShares().size());
     assertBigDecimalEquals(bd(9988), repositorySession.getPlayer().getMoney());
   }
@@ -49,28 +56,56 @@ public class SellShareUseCaseTest {
   @Test
   void execute_invalidSession_throwsException() {
     UUID unknownId = UUID.randomUUID();
-    UUID unknownShare = UUID.randomUUID();
 
     assertThrows(
         GameSessionNotFoundException.class,
-        () -> sellShare.execute(new SellShareUseCase.Request(unknownId, unknownShare)));
+        () -> sellShare.execute(new SellShareUseCase.Request(
+            unknownId,
+            "AAPL",
+            bd(1)
+        ))
+    );
   }
 
   @Test
-  void execute_invalidShareId_throwsException() {
-    buyShare.execute(new BuyShareUseCase.Request(session.getGameId(), "AAPL", bd(2)));
-    GameSession afterBuy = repository.findById(session.getGameId()).orElseThrow();
+  void execute_unknownSymbol_throwsException() {
+    BigDecimal moneyBefore = session.getPlayer().getMoney();
+    int sharesBefore = session.getPlayer().getPortfolio().getShares().size();
 
+    assertThrows(
+        NoSuchElementException.class,
+        () -> sellShare.execute(new SellShareUseCase.Request(
+            session.getGameId(),
+            "UNKNOWN",
+            bd(1)
+        ))
+    );
+
+    GameSession repositorySession = repository.findById(session.getGameId()).orElseThrow();
+
+    assertBigDecimalEquals(moneyBefore, repositorySession.getPlayer().getMoney());
+    assertEquals(sharesBefore, repositorySession.getPlayer().getPortfolio().getShares().size());
+  }
+
+  @Test
+  void execute_notEnoughShares_throwsException() {
+    buyShare.execute(new BuyShareUseCase.Request(session.getGameId(), "AAPL", bd(2)));
+
+    GameSession afterBuy = repository.findById(session.getGameId()).orElseThrow();
     BigDecimal moneyBefore = afterBuy.getPlayer().getMoney();
     int sharesBefore = afterBuy.getPlayer().getPortfolio().getShares().size();
 
     assertThrows(
-        NoSuchElementException.class,
-        () ->
-            sellShare.execute(
-                new SellShareUseCase.Request(session.getGameId(), UUID.randomUUID())));
+        IllegalStateException.class,
+        () -> sellShare.execute(new SellShareUseCase.Request(
+            session.getGameId(),
+            "AAPL",
+            bd(3)
+        ))
+    );
 
     GameSession repositorySession = repository.findById(session.getGameId()).orElseThrow();
+
     assertBigDecimalEquals(moneyBefore, repositorySession.getPlayer().getMoney());
     assertEquals(sharesBefore, repositorySession.getPlayer().getPortfolio().getShares().size());
   }

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSessionTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/game/GameSessionTest.java
@@ -132,7 +132,7 @@ public class GameSessionTest {
     Share boughtShare = session.getPlayer().getPortfolio().getShares().getFirst();
     session.finish();
 
-    assertThrows(GameSessionFinishedException.class, () -> session.sell(boughtShare.getShareId()));
+    assertThrows(GameSessionFinishedException.class, () -> session.sell(boughtShare.getStock().getSymbol(), boughtShare.getQuantity()));
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/market/ExchangeTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/market/ExchangeTest.java
@@ -155,7 +155,7 @@ public class ExchangeTest {
 
   @Test
   void sell_nullPlayer_throwsException() {
-    Share share = new Share(exchange.getStock("AAPL"), new BigDecimal("1"), new BigDecimal("100"));
+    Share share = new Share(exchange.getStock("AAPL"), new BigDecimal("1"), new BigDecimal("100"), 1);
     assertThrows(IllegalArgumentException.class, () -> exchange.sell(share.getShareId(), null));
   }
 

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/PlayerTest.java
@@ -104,7 +104,7 @@ public class PlayerTest {
   @Test
   void getNetWorth_returnsCashAndPortfolioValue() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("100"));
-    Share share = new Share(stock, bd("5"), bd("100"));
+    Share share = new Share(stock, bd("5"), bd("100"), 1);
     player.getPortfolio().addShare(share);
 
     BigDecimal expectedPrice = bd("595"); // money(100) + portfolioNetWorth(495)

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/PortfolioTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/PortfolioTest.java
@@ -24,9 +24,9 @@ class PortfolioTest {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
     Stock stock2 = new Stock("AAPL", "Apple", bd("400"));
 
-    share1 = new Share(stock, bd("5"), bd("310"));
-    share2 = new Share(stock, bd("10"), bd("320"));
-    share3 = new Share(stock2, bd("10"), bd("400"));
+    share1 = new Share(stock, bd("5"), bd("310"), 1);
+    share2 = new Share(stock, bd("10"), bd("320"), 1);
+    share3 = new Share(stock2, bd("10"), bd("400"), 1);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/ShareTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/ShareTest.java
@@ -15,13 +15,13 @@ class ShareTest {
   @BeforeEach
   void setUp() {
     stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
-    share = new Share(stock, bd("5"), bd("310"));
+    share = new Share(stock, bd("5"), bd("310"), 1);
   }
 
   @Test
   void constructor_validArguments_createsShare() {
     Stock stock = new Stock("AAPL", "Apple", bd("265"));
-    Share share = new Share(stock, bd("3"), bd("250"));
+    Share share = new Share(stock, bd("3"), bd("250"), 1);
 
     assertEquals(stock, share.getStock());
     assertEquals(bd("3"), share.getQuantity());
@@ -30,38 +30,38 @@ class ShareTest {
 
   @Test
   void constructor_nullStock_throwsIllegalArgumentException() {
-    assertThrows(IllegalArgumentException.class, () -> new Share(null, bd("10"), bd("6")));
+    assertThrows(IllegalArgumentException.class, () -> new Share(null, bd("10"), bd("6"), 1));
   }
 
   @Test
   void constructor_negativeQuantity_throwsIllegalArgumentException() {
-    assertThrows(IllegalArgumentException.class, () -> new Share(stock, bd("-7"), bd("20")));
+    assertThrows(IllegalArgumentException.class, () -> new Share(stock, bd("-7"), bd("20"), 1));
   }
 
   @Test
   void constructor_nullQuantity_throwsIllegalArgumentException() {
-    assertThrows(IllegalArgumentException.class, () -> new Share(stock, null, bd("20")));
+    assertThrows(IllegalArgumentException.class, () -> new Share(stock, null, bd("20"), 1));
   }
 
   @Test
   void constructor_zeroQuantity_throwsIllegalArgumentException() {
-    assertThrows(IllegalArgumentException.class, () -> new Share(stock, BigDecimal.ZERO, bd("20")));
+    assertThrows(IllegalArgumentException.class, () -> new Share(stock, BigDecimal.ZERO, bd("20"), 1));
   }
 
   @Test
   void constructor_negativePurchasePrice_throwsIllegalArgumentException() {
     assertThrows(
-        IllegalArgumentException.class, () -> new Share(stock, bd("7"), new BigDecimal("-1")));
+        IllegalArgumentException.class, () -> new Share(stock, bd("7"), new BigDecimal("-1"), 1));
   }
 
   @Test
   void constructor_nullPurchasePrice_throwsIllegalArgumentException() {
-    assertThrows(IllegalArgumentException.class, () -> new Share(stock, bd("7"), null));
+    assertThrows(IllegalArgumentException.class, () -> new Share(stock, bd("7"), null, 1));
   }
 
   @Test
   void constructor_zeroPurchasePrice_throwsIllegalArgumentException() {
-    assertThrows(IllegalArgumentException.class, () -> new Share(stock, bd("7"), BigDecimal.ZERO));
+    assertThrows(IllegalArgumentException.class, () -> new Share(stock, bd("7"), BigDecimal.ZERO, 1));
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/PurchaseTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/PurchaseTest.java
@@ -19,7 +19,7 @@ public class PurchaseTest {
   @BeforeEach
   void setup() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
-    share = new Share(stock, new BigDecimal("5"), bd("310"));
+    share = new Share(stock, new BigDecimal("5"), bd("310"), 1);
     purchase = new Purchase(share, 12);
     richPlayer = new Player("Test", bd("20000"));
     poorPlayer = new Player("Test2", bd("1"));
@@ -49,7 +49,7 @@ public class PurchaseTest {
   @Test
   void constructor_validArguments_createsShare() {
     Stock stock2 = new Stock("AAPL", "Apple", new BigDecimal("265"));
-    Share share2 = new Share(stock2, new BigDecimal("3"), new BigDecimal("250"));
+    Share share2 = new Share(stock2, new BigDecimal("3"), new BigDecimal("250"), 1);
     Purchase purchase2 = new Purchase(share2, 12);
 
     assertEquals(share2, purchase2.getShare());

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/PurchaseTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/PurchaseTest.java
@@ -7,6 +7,8 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.PurchaseCalculator;
 import java.math.BigDecimal;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,19 +22,19 @@ public class PurchaseTest {
   void setup() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
     share = new Share(stock, new BigDecimal("5"), bd("310"), 1);
-    purchase = new Purchase(share, 12);
+    purchase = new Purchase(share, 12, UUID.randomUUID());
     richPlayer = new Player("Test", bd("20000"));
     poorPlayer = new Player("Test2", bd("1"));
   }
 
   @Test
   void constructor_nullShare_throwsException() {
-    assertThrows(IllegalArgumentException.class, () -> new Purchase(null, 12));
+    assertThrows(IllegalArgumentException.class, () -> new Purchase(null, 12, UUID.randomUUID()));
   }
 
   @Test
   void constructor_negativeWeek_throwsException() {
-    assertThrows(IllegalArgumentException.class, () -> new Purchase(share, -12));
+    assertThrows(IllegalArgumentException.class, () -> new Purchase(share, -12, UUID.randomUUID()));
   }
 
   @Test
@@ -50,7 +52,7 @@ public class PurchaseTest {
   void constructor_validArguments_createsShare() {
     Stock stock2 = new Stock("AAPL", "Apple", new BigDecimal("265"));
     Share share2 = new Share(stock2, new BigDecimal("3"), new BigDecimal("250"), 1);
-    Purchase purchase2 = new Purchase(share2, 12);
+    Purchase purchase2 = new Purchase(share2, 12, UUID.randomUUID());
 
     assertEquals(share2, purchase2.getShare());
     assertEquals(12, purchase2.getWeek());

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/SaleTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/SaleTest.java
@@ -20,7 +20,7 @@ public class SaleTest {
   @BeforeEach
   void setup() {
     stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
-    share = new Share(stock, new BigDecimal("5"), bd("310"));
+    share = new Share(stock, new BigDecimal("5"), bd("310"), 1);
     sale = new Sale(share, 12);
     player = new Player("Test", bd("2000"));
     purchase = new Purchase(share, 1);
@@ -51,7 +51,7 @@ public class SaleTest {
   @Test
   void constructor_validArguments_createsShare() {
     Stock stock2 = new Stock("AAPL", "Apple", bd("265"));
-    Share share2 = new Share(stock, bd("3"), bd("250"));
+    Share share2 = new Share(stock, bd("3"), bd("250"), 1);
     Sale sale2 = new Sale(share2, 12);
 
     assertEquals(share2, sale2.getShare());

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/SaleTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/SaleTest.java
@@ -7,6 +7,8 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.calculator.SaleCalculator;
 import java.math.BigDecimal;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,19 +23,19 @@ public class SaleTest {
   void setup() {
     stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
     share = new Share(stock, new BigDecimal("5"), bd("310"), 1);
-    sale = new Sale(share, 12);
+    sale = new Sale(share, 12, UUID.randomUUID());
     player = new Player("Test", bd("2000"));
-    purchase = new Purchase(share, 1);
+    purchase = new Purchase(share, 1, UUID.randomUUID());
   }
 
   @Test
   void constructor_nullShare_throwsException() {
-    assertThrows(IllegalArgumentException.class, () -> new Sale(null, 12));
+    assertThrows(IllegalArgumentException.class, () -> new Sale(null, 12, UUID.randomUUID()));
   }
 
   @Test
   void constructor_negativeWeek_throwsException() {
-    assertThrows(IllegalArgumentException.class, () -> new Sale(share, -12));
+    assertThrows(IllegalArgumentException.class, () -> new Sale(share, -12, UUID.randomUUID()));
   }
 
   @Test
@@ -52,7 +54,7 @@ public class SaleTest {
   void constructor_validArguments_createsShare() {
     Stock stock2 = new Stock("AAPL", "Apple", bd("265"));
     Share share2 = new Share(stock, bd("3"), bd("250"), 1);
-    Sale sale2 = new Sale(share2, 12);
+    Sale sale2 = new Sale(share2, 12, UUID.randomUUID());
 
     assertEquals(share2, sale2.getShare());
     assertEquals(12, sale2.getWeek());

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionArchiveTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionArchiveTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import java.math.BigDecimal;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,36 +33,36 @@ public class TransactionArchiveTest {
 
   @Test
   void getTransaction_returnsFalseIfAlreadyContains() {
-    Purchase purchase = new Purchase(share, 1);
+    Purchase purchase = new Purchase(share, 1, UUID.randomUUID());
     assertTrue(archive.add(purchase));
     assertFalse(archive.add(purchase));
-    assertTrue(archive.add(new Purchase(share, 1)));
+    assertTrue(archive.add(new Purchase(share, 1, UUID.randomUUID())));
   }
 
   @Test
   void getTransaction_returnsTransaction() {
-    Purchase purchase = new Purchase(share, 1);
+    Purchase purchase = new Purchase(share, 1, UUID.randomUUID());
     archive.add(purchase);
     assertSame(purchase, archive.getTransactions(1).getFirst());
   }
 
   @Test
   void getPurchase_returnsPurchase() {
-    Purchase purchase = new Purchase(share, 1);
+    Purchase purchase = new Purchase(share, 1, UUID.randomUUID());
     archive.add(purchase);
     assertSame(purchase, archive.getPurchases(1).getFirst());
   }
 
   @Test
   void getSales_returnsSale() {
-    Sale sale = new Sale(share, 1);
+    Sale sale = new Sale(share, 1, UUID.randomUUID());
     archive.add(sale);
     assertSame(sale, archive.getSales(1).getFirst());
   }
 
   @Test
   void countDistinctWeeks_countsRight() {
-    archive.add(new Purchase(share, 1));
+    archive.add(new Purchase(share, 1, UUID.randomUUID()));
     assertEquals(1, archive.countDistinctWeeks());
   }
 

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionArchiveTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionArchiveTest.java
@@ -15,7 +15,7 @@ public class TransactionArchiveTest {
   @BeforeEach
   void setup() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("330"));
-    share = new Share(stock, bd("5"), bd("310"));
+    share = new Share(stock, bd("5"), bd("310"), 1);
     archive = new TransactionArchive();
   }
 

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionFactoryTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/TransactionFactoryTest.java
@@ -16,7 +16,7 @@ public class TransactionFactoryTest {
   void setup() {
     factory = new TransactionFactory();
     Stock stock = new Stock("AAPL", "Apple", bd("250"));
-    share = new Share(stock, bd("3"), bd("250"));
+    share = new Share(stock, bd("3"), bd("250"), 1);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/calculator/PurchaseCalculatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/calculator/PurchaseCalculatorTest.java
@@ -15,7 +15,7 @@ public class PurchaseCalculatorTest {
   @BeforeEach
   void setup() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("100"));
-    share = new Share(stock, bd("5"), bd("100"));
+    share = new Share(stock, bd("5"), bd("100"), 1);
     calc = new PurchaseCalculator(share);
   }
 

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/calculator/SaleCalculatorTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/trade/calculator/SaleCalculatorTest.java
@@ -15,7 +15,7 @@ public class SaleCalculatorTest {
   @BeforeEach
   void setup() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("100"));
-    share = new Share(stock, bd("5"), bd("100"));
+    share = new Share(stock, bd("5"), bd("100"), 1);
     calc = new SaleCalculator(share);
   }
 
@@ -47,7 +47,7 @@ public class SaleCalculatorTest {
   @Test
   void calculateTax_profitableSale_tax30Percent() {
     Stock stock = new Stock("KOG", "Kongsberg Gruppen", bd("200"));
-    share = new Share(stock, bd("1"), bd("100"));
+    share = new Share(stock, bd("1"), bd("100"), 1);
     calc = new SaleCalculator(share);
     BigDecimal profit = bd("100").subtract(calc.calculateCommission());
 


### PR DESCRIPTION
## Summary
- Refactored order popup into input, preview, confirmation, and draft order components
- Added support for buy now, sell now, buy at target price, sell at target price, and stop-loss orders
- Added use cases for buy limit, sell limit, and stop-loss orders
- Added pending orders query flow and Orders page
- Updated sell flow to support selling by symbol and quantity

## Testing
- Ran mvn test
- Manually tested market buy/sell and pending order flows