### PR TITLE
Feat/display player name

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/application/query/GetAllSavesUseCase.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/application/query/GetAllSavesUseCase.java
@@ -19,7 +19,7 @@ public final class GetAllSavesUseCase {
             s.getGameId(),
             s.getPlayer().getName(),
             s.getExchange().getWeek(),
-            s.getPlayer().getStatus(s.getExchange()),
+            s.getPlayer().getStatus(),
             s.getPlayer().getNetWorth(),
             s.getLastPlayed(),
             s.getState() == GameSessionState.FINISHED

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/Player.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/Player.java
@@ -177,16 +177,16 @@ public class Player {
    * <p>Calculates the players status based on their net worth
    * and for how many weeks they have played.
    *
-   * @param exchange the exchange the user is trading their stocks in
    * @return the players status title as a string
    * @throws IllegalArgumentException if {@code exchange} is null
    */
-  public String getStatus(Exchange exchange) {
-    Validate.notNull(exchange, "Exchange");
-    int week = exchange.getWeek();
-    if (money.compareTo(startingMoney.multiply(BigDecimal.TWO)) > 0 && week >= 20) {
+  public String getStatus() {
+    int tradedWeeks = transactionArchive.countDistinctWeeks();
+    BigDecimal netWorth = getNetWorth();
+
+    if (netWorth.compareTo(startingMoney.multiply(BigDecimal.TWO)) > 0 && tradedWeeks >= 20) {
       return "Speculator";
-    } else if (money.compareTo(startingMoney.multiply(BigDecimal.valueOf(1.2))) > 0 && week >= 10) {
+    } else if (netWorth.compareTo(startingMoney.multiply(BigDecimal.valueOf(1.2))) > 0 && tradedWeeks >= 10) {
       return "Investor";
     } else {
       return "Novice";

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/infrastructure/repository/LeaderboardFileHandler.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/infrastructure/repository/LeaderboardFileHandler.java
@@ -61,8 +61,8 @@ public class LeaderboardFileHandler {
     return List.of(
         new LeaderboardEntry(
             "Kristian",
-            LeaderboardEntry.calculateScore(1000, new BigDecimal("5000")),
-            1000,
+            LeaderboardEntry.calculateScore(3000, new BigDecimal("5000")),
+            3000,
             new BigDecimal("1000000"),
             new BigDecimal("5000"),
             Difficulty.HARD,
@@ -70,8 +70,8 @@ public class LeaderboardFileHandler {
         ),
         new LeaderboardEntry(
             "Marius",
-            LeaderboardEntry.calculateScore(500, new BigDecimal("25000")),
-            500,
+            LeaderboardEntry.calculateScore(1000, new BigDecimal("25000")),
+            1000,
             new BigDecimal("1000000"),
             new BigDecimal("25000"),
             Difficulty.MEDIUM,
@@ -79,8 +79,8 @@ public class LeaderboardFileHandler {
         ),
         new LeaderboardEntry(
             "Stonk Master",
-            LeaderboardEntry.calculateScore(200, new BigDecimal("100000")),
-            200,
+            LeaderboardEntry.calculateScore(500, new BigDecimal("50000")),
+            500,
             new BigDecimal("1000000"),
             new BigDecimal("50000"),
             Difficulty.EASY,

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/NavBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/NavBar.java
@@ -9,10 +9,12 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 
 /**
  * Top navigation bar for the application.
@@ -29,6 +31,7 @@ public class NavBar extends HBox {
   private final Label nameLabel;
   private final Label statusLabel;
   private final ProgressBar levelProgress;
+  private final Tooltip levelTip = new Tooltip();
 
   /**
    * Listener interface for navigation events triggered by the nav bar.
@@ -73,6 +76,8 @@ public class NavBar extends HBox {
     levelProgress.getStyleClass().add("level-progress");
     levelProgress.setPrefWidth(120);
     levelProgress.setPrefHeight(6);
+    levelTip.setShowDelay(Duration.millis(200));
+    levelProgress.setTooltip(levelTip);
 
     VBox playerInfo = new VBox(2, nameLabel, statusLabel, levelProgress);
     playerInfo.setAlignment(Pos.CENTER_RIGHT);
@@ -98,11 +103,13 @@ public class NavBar extends HBox {
    * @param name     the player's name
    * @param status   the player's current status label (e.g. "Novice", "Investor", "Speculator")
    * @param progress progress toward the next status level, between {@code 0.0} and {@code 1.0}
+   * @param tip      hover text explaining what is still needed for the next level
    */
-  public void updatePlayerInfo(String name, String status, double progress) {
+  public void updatePlayerInfo(String name, String status, double progress, String tip) {
     nameLabel.setText(name);
     statusLabel.setText(status);
     levelProgress.setProgress(progress);
+    levelTip.setText(tip);
 
     levelProgress.getStyleClass().removeIf(c -> c.startsWith("level-progress-"));
     levelProgress.getStyleClass().add("level-progress-" + status.toLowerCase());

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/NavBar.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/NavBar.java
@@ -60,4 +60,13 @@ public class NavBar extends HBox {
     });
     return btn;
   }
+
+  public void updatePlayerInfo(String name, String status, double progress) {
+    nameLabel.setText(name);
+    statusLabel.setText(status);
+    levelProgress.setProgress(progress);
+
+    levelProgress.getStyleClass().removeIf(c -> c.startsWith("level-progress-"));
+    levelProgress.getStyleClass().add("level-progress-" + status.toLowerCase());
+  }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
@@ -57,7 +57,8 @@ public class GameViewCoordinator {
   private NavigationManager navManager;
   private BorderPane root;
   private ShopView shopView;
-  private StackPane popupHost;   // ← ny linje
+  private StackPane popupHost;
+  private NavBar navBar;
 
   private HBox bottomBar;
   private Label weekValue;
@@ -87,8 +88,8 @@ public class GameViewCoordinator {
   }
 
   public Scene getScene() {
-    navManager = new NavigationManager(buildPages());
-    NavBar navBar = new NavBar(navManager::navigateTo);
+    navBar = new NavBar(navManager::navigateTo);
+    refreshNavBar();
 
     root = new BorderPane();
     root.setTop(navBar);
@@ -290,6 +291,8 @@ public class GameViewCoordinator {
 
     bottomBar.getStyleClass().remove("bottom-bar-danger");
     if (danger) bottomBar.getStyleClass().add("bottom-bar-danger");
+
+    refreshNavBar();
   }
 
   private void showPopup(Node popup) {
@@ -298,5 +301,26 @@ public class GameViewCoordinator {
 
   private void closePopup(Node popup) {
     popupHost.getChildren().remove(popup);
+  }
+
+  private void refreshNavBar() {
+    Player player     = bundle.session().getPlayer();
+    Exchange exchange = bundle.session().getExchange();
+
+    String status = player.getStatus(exchange);
+    BigDecimal money = player.getMoney();
+    BigDecimal start = player.getStartingMoney();
+
+    double progress = switch (status) {
+      case "Investor"   -> money.subtract(start.multiply(BigDecimal.valueOf(1.2)))
+          .divide(start.multiply(BigDecimal.valueOf(0.8)), 4, RoundingMode.HALF_UP)
+          .doubleValue();
+      case "Speculator" -> 1.0;
+      default           -> money.subtract(start)
+          .divide(start.multiply(BigDecimal.valueOf(0.2)), 4, RoundingMode.HALF_UP)
+          .doubleValue();
+    };
+
+    navBar.updatePlayerInfo(player.getName(), status, Math.max(0.02, Math.clamp(progress, 0.0, 1.0)));
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
@@ -297,24 +297,70 @@ public class GameViewCoordinator {
   }
 
   private void refreshNavBar() {
-    Player player   = bundle.session().getPlayer();
-    Exchange exchange = bundle.session().getExchange();
+    Player player = bundle.session().getPlayer();
 
-    String status = player.getStatus(exchange);
-    BigDecimal money = player.getMoney();
+    String status = player.getStatus();
+    BigDecimal netWorth = player.getNetWorth();
     BigDecimal start = player.getStartingMoney();
+    int tradedWeeks = player.getTransactionArchive().countDistinctWeeks();
 
-    double progress = switch (status) {
-      case "Investor"   -> money.subtract(start.multiply(BigDecimal.valueOf(1.2)))
-          .divide(start.multiply(BigDecimal.valueOf(0.8)), 4, RoundingMode.HALF_UP)
-          .doubleValue();
-      case "Speculator" -> 1.0;
-      default           -> money.subtract(start)
-          .divide(start.multiply(BigDecimal.valueOf(0.2)), 4, RoundingMode.HALF_UP)
-          .doubleValue();
-    };
+    double progress;
+    String tip;
 
-    navBar.updatePlayerInfo(player.getName(), status, Math.clamp(progress, 0.0, 1.0));
+    switch (status) {
+      case "Speculator" -> {
+        progress = 1.0;
+        tip = "You've reached the highest status — Speculator.";
+      }
+      case "Investor" -> {
+        double equity = netWorth.subtract(start.multiply(BigDecimal.valueOf(1.2)))
+            .divide(start.multiply(BigDecimal.valueOf(0.8)), 4, RoundingMode.HALF_UP)
+            .doubleValue();
+        double time = (tradedWeeks - 10) / 10.0;          // 10 → 20 uker
+        progress = Math.min(equity, time);
+        tip = nextStatusTip("Speculator", equity, tradedWeeks, 20,
+            start.multiply(BigDecimal.TWO));
+      }
+      default -> {
+        double equity = netWorth.subtract(start)
+            .divide(start.multiply(BigDecimal.valueOf(0.2)), 4, RoundingMode.HALF_UP)
+            .doubleValue();
+        double time = tradedWeeks / 10.0;                 // 0 → 10 uker
+        progress = Math.min(equity, time);
+        tip = nextStatusTip("Investor", equity, tradedWeeks, 10,
+            start.multiply(BigDecimal.valueOf(1.2)));
+      }
+    }
+
+    navBar.updatePlayerInfo(player.getName(), status, Math.clamp(progress, 0.0, 1.0), tip);
+  }
+
+  /**
+   * Builds a hint describing what the player still needs to reach the next status.
+   *
+   * @param next           name of the next status level
+   * @param equityProgress net-worth progress toward that level, 0.0–1.0
+   * @param tradedWeeks    number of distinct weeks the player has traded
+   * @param weeksNeeded    weeks required for the next status
+   * @param netWorthTarget net worth required for the next status
+   * @return a human-readable hint
+   */
+  private String nextStatusTip(String next, double equityProgress,
+                               int tradedWeeks, int weeksNeeded, BigDecimal netWorthTarget) {
+    boolean equityDone = equityProgress >= 1.0;
+    int weeksLeft = Math.max(0, weeksNeeded - tradedWeeks);
+
+    if (equityDone && weeksLeft > 0) {
+      return "Net worth is high enough for " + next + " — keep trading "
+          + weeksLeft + " more " + (weeksLeft == 1 ? "week" : "weeks") + ".";
+    }
+    if (!equityDone && weeksLeft == 0) {
+      return "You've traded enough — reach "
+          + MoneyFormat.formatCurrency(netWorthTarget) + " net worth for " + next + ".";
+    }
+    return "To reach " + next + ": "
+        + MoneyFormat.formatCurrency(netWorthTarget) + " net worth and "
+        + weeksLeft + " more " + (weeksLeft == 1 ? "week" : "weeks") + " of trading.";
   }
 
   private void showPopup(Node popup) {

--- a/src/main/resources/css/base.css
+++ b/src/main/resources/css/base.css
@@ -1105,9 +1105,15 @@
     -fx-font-size: 11px;
 }
 
+.level-progress {
+    -fx-padding: 0;
+    -fx-background-color: transparent;
+}
+
 .level-progress .track {
-    -fx-background-color: -bg-elevated;
+    -fx-background-color: -border;
     -fx-background-radius: 3;
+    -fx-padding: 0;
 }
 
 .level-progress .bar {

--- a/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/PlayerTest.java
+++ b/src/test/java/edu/ntnu/idatt2003/gruppe50/domain/portfolio/PlayerTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.ntnu.idatt2003.gruppe50.domain.game.Difficulty;
 import edu.ntnu.idatt2003.gruppe50.domain.market.Exchange;
 import edu.ntnu.idatt2003.gruppe50.domain.market.Stock;
+import edu.ntnu.idatt2003.gruppe50.domain.trade.Purchase;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.TransactionArchive;
 import edu.ntnu.idatt2003.gruppe50.domain.trade.TransactionFactory;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -113,55 +116,49 @@ public class PlayerTest {
   }
 
   @Test
-  void getStatus_nullExchange_throwsException() {
-    assertThrows(IllegalArgumentException.class, () -> player.getStatus(null));
-  }
-
-  @Test
   void getStatus_beforeWeek10_returnsNovice() {
-    Exchange ex = exchangeAtWeek(1);
+    tradeForWeeks(1);
     player.addMoney(bd(1000));
-    assertEquals("Novice", player.getStatus(ex));
+    assertEquals("Novice", player.getStatus());
   }
 
   @Test
   void getStatus_week10_over20Percent_returnsInvestor() {
-    Exchange ex = exchangeAtWeek(10);
+    tradeForWeeks(10);
     player.addMoney(bd(21));
-    assertEquals("Investor", player.getStatus(ex));
+    assertEquals("Investor", player.getStatus());
   }
 
   @Test
   void getStatus_week10_under20Percent_returnsNotInvestor() {
-    Exchange ex = exchangeAtWeek(10);
+    tradeForWeeks(10);
     player.addMoney(bd(20));
-    assertEquals("Novice", player.getStatus(ex));
-    assertNotEquals("Investor", player.getStatus(ex));
+    assertEquals("Novice", player.getStatus());
+    assertNotEquals("Investor", player.getStatus());
   }
 
   @Test
   void getStatus_week20_over100Percent_returnsSpeculator() {
-    Exchange ex = exchangeAtWeek(20);
+    tradeForWeeks(20);
     player.addMoney(bd(101));
-    assertEquals("Speculator", player.getStatus(ex));
+    assertEquals("Speculator", player.getStatus());
   }
 
   @Test
   void getStatus_week20_under100Percent_returnsNotSpeculator() {
-    Exchange ex = exchangeAtWeek(20);
+    tradeForWeeks(20);
     player.addMoney(bd(100));
-    assertNotEquals("Speculator", player.getStatus(ex));
-    assertEquals("Investor", player.getStatus(ex));
+    assertNotEquals("Speculator", player.getStatus());
+    assertEquals("Investor", player.getStatus());
   }
 
-  // helper method
-  private Exchange exchangeAtWeek(int week) {
-    Exchange ex =
-        new Exchange("OSL", List.of(new Stock("AAPL", "Apple", bd(100))), new TransactionFactory(), Difficulty.MEDIUM.toVolatilityProfile());
-    for (int i = 0; i < week; i++) {
-      ex.advance();
+  // helper: registers one transaction per week so countDistinctWeeks() == weeks
+  private void tradeForWeeks(int weeks) {
+    Stock stock = new Stock("AAPL", "Apple", bd(100));
+    for (int week = 1; week <= weeks; week++) {
+      Share share = new Share(stock, bd("1"), bd("100"), week);
+      player.getTransactionArchive().add(new Purchase(share, week, UUID.randomUUID()));
     }
-    return ex;
   }
 
   private BigDecimal bd(double num) {


### PR DESCRIPTION
Adds a player identity section to the navbar showing the player's name, current status, and progress toward the next status level.

Changes
Player identity section — name, status (Novice / Investor / Speculator) and a level-progress bar in the navbar, with per-status color theming.
Status now reflects actual trading activity. Player.getStatus() previously read the week count from the Exchange; it now derives status from net worth and the number of distinct weeks the player has traded (countDistinctWeeks()). The method no longer takes an Exchange argument.
Progress bar shows the binding constraint. Status requires both enough net worth and enough traded weeks. The bar now displays the minimum of the two sub-progresses, so it no longer fills up before the player can actually rank up.
Hover tooltip on the progress bar explains what is still needed for the next status (e.g. "keep trading 4 more weeks").