### PR TITLE
fix: make week overview vertically scrollable

### DIFF
--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/VolatilityProfile.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/market/VolatilityProfile.java
@@ -1,7 +1,10 @@
 package edu.ntnu.idatt2003.gruppe50.domain.market;
 
 /**
- * Immutable value object describing market volatility parameters.
- * Controls direction bias and magnitude of weekly price swings in Exchange.
+ * Describes how much stock prices can change in the market.
+ *
+ * @param upChance the chance that a stock price goes up
+ * @param maxGain the highest possible price increase
+ * @param maxLoss the highest possible price decrease
  */
 public record VolatilityProfile(double upChance, double maxGain, double maxLoss) {}

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/shop/items/ThemeItem.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/domain/shop/items/ThemeItem.java
@@ -4,7 +4,6 @@ import edu.ntnu.idatt2003.gruppe50.domain.game.Difficulty;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Player;
 import edu.ntnu.idatt2003.gruppe50.domain.shop.ShopItem;
 import edu.ntnu.idatt2003.gruppe50.shared.Validate;
-
 import java.math.BigDecimal;
 import java.util.EnumMap;
 import java.util.Map;

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/week/WeekSummaryPopup.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/components/popup/week/WeekSummaryPopup.java
@@ -1,10 +1,11 @@
-package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup;
+package edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.week;
 
 import edu.ntnu.idatt2003.gruppe50.ui.model.WeekSummary;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.week.WeekDetailListView;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.week.WeekSummaryView;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -26,7 +27,7 @@ public class WeekSummaryPopup extends StackPane {
     this.card = new VBox(15);
     card.getStyleClass().add("week-summary-popup");
     card.setMaxWidth(560);
-    card.setMaxHeight(Region.USE_PREF_SIZE);
+    card.setMaxHeight(620);
 
     getChildren().addAll(backdrop, card);
 
@@ -43,7 +44,7 @@ public class WeekSummaryPopup extends StackPane {
         this::showNotifications,
         onClose
     );
-    card.getChildren().setAll(view);
+    card.getChildren().setAll(scrollable(view));
   }
 
   private void showNews() {
@@ -64,5 +65,15 @@ public class WeekSummaryPopup extends StackPane {
         onClose
     );
     card.getChildren().setAll(view);
+  }
+
+  private ScrollPane scrollable(VBox content) {
+    ScrollPane scroll = new ScrollPane(content);
+    scroll.setFitToWidth(true);
+    scroll.setMaxHeight(620);
+    scroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+    scroll.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+    scroll.getStyleClass().add("week-summary-scroll");
+    return scroll;
   }
 }

--- a/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
+++ b/src/main/java/edu/ntnu/idatt2003/gruppe50/ui/view/pages/GameViewCoordinator.java
@@ -17,16 +17,14 @@ import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Share;
 import edu.ntnu.idatt2003.gruppe50.domain.portfolio.Status;
 import edu.ntnu.idatt2003.gruppe50.infrastructure.repository.LeaderboardFileHandler;
 import edu.ntnu.idatt2003.gruppe50.shared.MoneyFormat;
-import edu.ntnu.idatt2003.gruppe50.ui.view.WindowConfig;
 import edu.ntnu.idatt2003.gruppe50.ui.model.WeekHolding;
 import edu.ntnu.idatt2003.gruppe50.ui.model.WeekSummary;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.NavBar;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.factory.ButtonFactory;
 import edu.ntnu.idatt2003.gruppe50.ui.view.components.factory.StatCardFactory;
-import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.WeekSummaryPopup;
+import edu.ntnu.idatt2003.gruppe50.ui.view.components.popup.week.WeekSummaryPopup;
 import edu.ntnu.idatt2003.gruppe50.ui.view.navigation.NavigationManager;
 import edu.ntnu.idatt2003.gruppe50.ui.view.navigation.PageId;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;


### PR DESCRIPTION
## Summary
Makes the week overview vertically scrollable to prevent content from being clipped on smaller screen sizes.

## Changes
- Wrapped week overview in a vertical scroll container